### PR TITLE
Bug fix: check subjectPublicKeyInfo.algorithm not signatureAlgorithm, add OID 1.2.840.113549.1.1.1

### DIFF
--- a/org/pkijs/cms_simpl.js
+++ b/org/pkijs/cms_simpl.js
@@ -2323,7 +2323,7 @@ function(in_window)
                 // #endregion 
 
                 // #region Get information about public key algorithm and default parameters for import
-                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(signer_cert.signatureAlgorithm.algorithm_id);
+                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(signer_cert.subjectPublicKeyInfo.algorithm.algorithm_id);
                 if(("name" in algorithmObject) === false)
                 {
                     if(extendedMode)
@@ -2331,14 +2331,14 @@ function(in_window)
                         return Promise.reject({
                             date: checkDate,
                             code: 11,
-                            message: "Unsupported public key algorithm: " + signer_cert.signatureAlgorithm.algorithm_id,
+                            message: "Unsupported public key algorithm: " + signer_cert.subjectPublicKeyInfo.algorithm.algorithm_id,
                             signatureVerified: null,
                             signerCertificate: signer_cert,
                             signerCertificateVerified: true
                         });
                     }
 
-                    return Promise.reject("Unsupported public key algorithm: " + signer_cert.signatureAlgorithm.algorithm_id);
+                    return Promise.reject("Unsupported public key algorithm: " + signer_cert.subjectPublicKeyInfo.algorithm.algorithm_id);
                 }
 
                 var algorithm_name = algorithmObject.name;

--- a/org/pkijs/common.js
+++ b/org/pkijs/common.js
@@ -1012,6 +1012,11 @@ function(in_window)
 
         switch(oid)
         {
+            case "1.2.840.113549.1.1.1":
+                result = {
+                    name: "RSASSA-PKCS1-v1_5"
+                };
+                break;
             case "1.2.840.113549.1.1.5":
                 result = {
                     name: "RSASSA-PKCS1-v1_5",

--- a/org/pkijs/ocsp_tsp_simpl.js
+++ b/org/pkijs/ocsp_tsp_simpl.js
@@ -1898,9 +1898,9 @@ function(in_window)
             function()
             {
                 // #region Get information about public key algorithm and default parameters for import
-                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(certs[cert_index].signatureAlgorithm.algorithm_id);
+                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(certs[cert_index].subjectPublicKeyInfo.algorithm.algorithm_id);
                 if(("name" in algorithmObject) === false)
-                    return Promise.reject("Unsupported public key algorithm: " + certs[cert_index].signatureAlgorithm.algorithm_id);
+                    return Promise.reject("Unsupported public key algorithm: " + certs[cert_index].subjectPublicKeyInfo.algorithm.algorithm_id);
 
                 var algorithm_name = algorithmObject.name;
 

--- a/org/pkijs/x509_simpl.js
+++ b/org/pkijs/x509_simpl.js
@@ -4121,9 +4121,9 @@ function(in_window)
             function()
             {
                 // #region Get information about public key algorithm and default parameters for import
-                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(_this.signatureAlgorithm.algorithm_id);
+                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(_this.subjectPublicKeyInfo.algorithm.algorithm_id);
                 if(("name" in algorithmObject) === false)
-                    return Promise.reject("Unsupported public key algorithm: " + _this.signatureAlgorithm.algorithm_id);
+                    return Promise.reject("Unsupported public key algorithm: " + _this.subjectPublicKeyInfo.algorithm.algorithm_id);
 
                 var algorithm_name = algorithmObject.name;
 
@@ -4384,9 +4384,9 @@ function(in_window)
             // #endregion   
 
             // #region Get information about public key algorithm and default parameters for import
-            var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(this.signatureAlgorithm.algorithm_id);
+            var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(this.subjectPublicKeyInfo.algorithm.algorithm_id);
             if(("name" in algorithmObject) === false)
-                return Promise.reject("Unsupported public key algorithm: " + _this.signatureAlgorithm.algorithm_id);
+                return Promise.reject("Unsupported public key algorithm: " + _this.subjectPublicKeyInfo.algorithm.algorithm_id);
 
             var algorithm_name = algorithmObject.name;
 
@@ -4856,9 +4856,9 @@ function(in_window)
             function()
             {
                 // #region Get information about public key algorithm and default parameters for import
-                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(_this.signature.algorithm_id);
+                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(_this.subjectPublicKeyInfo.algorthim.algorithm_id);
                 if(("name" in algorithmObject) === "")
-                    return Promise.reject("Unsupported public key algorithm: " + _this.signature.algorithm_id);
+                    return Promise.reject("Unsupported public key algorithm: " + _this.subjectPublicKeyInfo.algorithm.algorithm_id);
 
                 var algorithm_name = algorithmObject.name;
 
@@ -5428,9 +5428,9 @@ function(in_window)
             function()
             {
                 // #region Get information about public key algorithm and default parameters for import
-                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(_this.signatureAlgorithm.algorithm_id);
+                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(_this.subjectPublicKeyInfo.algorithm.algorithm_id);
                 if(("name" in algorithmObject) === false)
-                    return Promise.reject("Unsupported public key algorithm: " + _this.signatureAlgorithm.algorithm_id);
+                    return Promise.reject("Unsupported public key algorithm: " + _this.subjectPublicKeyInfo.algorithm.algorithm_id);
 
                 var algorithm_name = algorithmObject.name;
 


### PR DESCRIPTION
I found that in my test cases, I have S/MIME messages whose public key algorithm differs from the issuer's signature algorithm. There were places in the code that check the signature algorithm instead of the actual public key algorithm, and when the two differ, spurious failures result.

I also found that OID 1.2.840.113549.1.1.1 was not being handled, so I added that.