### PR TITLE
Check subjectPublicKeyInfo.algorithm not signatureAlgorithm; add OID for rsa encryption

### DIFF
--- a/org/pkijs/cms_simpl.js
+++ b/org/pkijs/cms_simpl.js
@@ -2323,7 +2323,7 @@ function(in_window)
                 // #endregion 
 
                 // #region Get information about public key algorithm and default parameters for import
-                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(signer_cert.signatureAlgorithm.algorithm_id);
+                var algorithmObject = in_window.org.pkijs.getAlgorithmByOID(signer_cert.subjectPublicKeyInfo.algorithm.algorithm_id);
                 if(("name" in algorithmObject) === false)
                 {
                     if(extendedMode)
@@ -2331,14 +2331,14 @@ function(in_window)
                         return Promise.reject({
                             date: checkDate,
                             code: 11,
-                            message: "Unsupported public key algorithm: " + signer_cert.signatureAlgorithm.algorithm_id,
+                            message: "Unsupported public key algorithm: " + signer_cert.subjectPublicKeyInfo.algorithm.algorithm_id,
                             signatureVerified: null,
                             signerCertificate: signer_cert,
                             signerCertificateVerified: true
                         });
                     }
 
-                    return Promise.reject("Unsupported public key algorithm: " + signer_cert.signatureAlgorithm.algorithm_id);
+                    return Promise.reject("Unsupported public key algorithm: " + signer_cert.subjectPublicKeyInfo.algorithm.algorithm_id);
                 }
 
                 var algorithm_name = algorithmObject.name;

--- a/org/pkijs/common.js
+++ b/org/pkijs/common.js
@@ -1012,6 +1012,11 @@ function(in_window)
 
         switch(oid)
         {
+            case "1.2.840.113549.1.1.1":
+                result = {
+                    name: "RSASSA-PKCS1-v1_5"
+                };
+                break;
             case "1.2.840.113549.1.1.5":
                 result = {
                     name: "RSASSA-PKCS1-v1_5",


### PR DESCRIPTION
This is a simplified version of my previous pull request. I only changed `signatureAlgorithm` to `subjectPublicKeyInfo.algorithm` in one block cms_simpl.js here.

In the previous pull request, I was over-aggressive in replacing similar code starting with `var algorithmObject = ...` In those cases, I think it's more subtle, and I don't know if it should be `subjectPublicKeyInfo` or `this.subjectPublicKeyInfo`, etc. Doing the naive thing of just changing `signatureAlgorithm` to `subjectPublicKeyInfo.algorithm` seemed to be wrong and led to mysterious "input_buffer has zero length" errors.  Hopefully you guys can look through the other code with `var algorithmObject = ...` and comments about public keys (but code about signatures) and make the appropriate changes. 