### PR TITLE
Fix AuthorityKeyIdentifier.toSchema.

### DIFF
--- a/src/AuthorityKeyIdentifier.js
+++ b/src/AuthorityKeyIdentifier.js
@@ -195,9 +195,7 @@ export default class AuthorityKeyIdentifier
 					tagClass: 3, // CONTEXT-SPECIFIC
 					tagNumber: 1 // [1]
 				},
-				value: [new asn1js.Sequence({
-					value: Array.from(this.authorityCertIssuer, element => element.toSchema())
-				})]
+				value: Array.from(this.authorityCertIssuer, element => element.toSchema())
 			}));
 		}
 		


### PR DESCRIPTION
AuthorityKeyIdentifier.toSchema produces invalid results that cannot be validated by AuthorityKeyIdentifier.fromSchema.