### PR TITLE
Import babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "rollem": "git+https://github.com/PeculiarVentures/rollem.git",
     "rollup": "0.34.7",
     "rollup-plugin-commonjs": "^8.2.6",
-    "rollup-plugin-node-resolve": "^1.7.1"
+    "rollup-plugin-node-resolve": "^1.7.1",
+    "babel-polyfill": "6.26.0"
   },
   "dependencies": {
     "asn1js": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import { setEngine, getEngine, getCrypto, getRandomValues, getOIDByAlgorithm, getAlgorithmParameters, createCMSECDSASignature, stringPrep, createECDSASignatureFromCMS, getAlgorithmByOID, getHashAlgorithm, kdfWithCounter, kdf } from "./common";
 export { setEngine, getEngine, getCrypto, getRandomValues, getOIDByAlgorithm, getAlgorithmParameters, createCMSECDSASignature, stringPrep, createECDSASignatureFromCMS, getAlgorithmByOID, getHashAlgorithm, kdfWithCounter, kdf };
 import AccessDescription from "./AccessDescription";


### PR DESCRIPTION
babel-polyfill is needed to fix a problem during certificate
chain validation. It has been added as a devDependency.