### PR TITLE
add node.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ PKI.js V2 (ES2015 version) is **incompatible** with PKI.js V1 code. In order to 
 
 ```
 
-### Use in node.js
+### Use in Node.js
 
 ``` javascript
     require("babel-polyfill");

--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ PKI.js V2 (ES2015 version) is **incompatible** with PKI.js V1 code. In order to 
 
 ```
 
+### Use in node.js
+
+``` javascript
+    require("babel-polyfill");
+    const asn1js = require("asn1js");
+    const pkijs = require("pkijs");
+    const Certificate = pkijs.Certificate;
+
+    const buffer = new Uint8Array([
+        // ... cert hex bytes ...
+    ]).buffer;
+
+    const asn1 = asn1js.fromBER(buffer);
+    const certificate = new Certificate({ schema: asn1.result });
+```
+
 More examples could be found in [**examples**](https://github.com/PeculiarVentures/PKI.js/tree/master/examples) folder. To run these samples you must compile them, for example you would run:
 
 ```


### PR DESCRIPTION
In light of issues #113, #152, #155 and [especially @rmhrisk 's comment](https://github.com/PeculiarVentures/PKI.js/issues/113#issuecomment-366570224) this is a simple documentation fix to:
1. Prevent future issues from being opened about `require("pkijs")` breaking with `regeneratorRuntime is not defined` or similar errors; and
2. Help people find their way on node.js faster (I know it would have saved me >15 minutes of thinking I was crazy, reading the examples, and eventually finding the right issue with the solution).