### PR TITLE
Use browser mode in Electron's renderer process

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -14,7 +14,7 @@ export function setEngine(name, crypto, subtle)
 {
 	//region We are in Node
 	// noinspection JSUnresolvedVariable
-	if((typeof process !== "undefined") && ("pid" in process) && (typeof global !== "undefined"))
+	if((typeof process !== "undefined") && ("pid" in process) && (typeof global !== "undefined") && (typeof window === "undefined"))
 	{
 		// noinspection ES6ModulesDependencies, JSUnresolvedVariable
 		if(typeof global[process.pid] === "undefined")


### PR DESCRIPTION
Currently importing doesn't work in Electron's renderer process. This is because it's a hybrid environment that's browser, but has Node.js integration, and it looks like PKI.js is considering it Node.js rather than browser, and then using indexed set on `global` causes a `TypeError`. This PR adds an extra check when determining if the runtime environment is Node.js.