### PR TITLE
fix license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "main": "./build/index.js",
   "name": "pkijs",
   "version": "2.1.74",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "esdoc": {
     "source": "./src",
     "destination": "./docs",


### PR DESCRIPTION
The LICENSE file in this repo is a BSD-3-Clause license, not MIT.
Updating the package.json to reflect the reality of the source.

For reference, here's the licenses from [OSI](https://opensource.org/) where you can see that
the LICENSE file is verbatim [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause) and not [MIT](https://opensource.org/licenses/MIT).