### PR TITLE
Add support for verification of CMS SignedData values with detached certificates

### DIFF
--- a/src/CertificateSet.js
+++ b/src/CertificateSet.js
@@ -143,33 +143,35 @@ export default class CertificateSet
 		//endregion
 		
 		//region Get internal properties from parsed schema
-		this.certificates = Array.from(asn1.result.certificates, element =>
-		{
-			const initialTagNumber = element.idBlock.tagNumber;
-
-			if(element.idBlock.tagClass === 1)
-				return new Certificate({ schema: element });
-			
-			//region Making "Sequence" from "Constructed" value
-			const elementSequence = new asn1js.Sequence({
-				value: element.valueBlock.value
-			});
-			//endregion
-
-			switch(initialTagNumber)
+		if (asn1.result.certificates) {
+			this.certificates = Array.from(asn1.result.certificates, element =>
 			{
-				case 1:
-					return new AttributeCertificateV1({ schema: elementSequence });
-				case 2:
-					return new AttributeCertificateV2({ schema: elementSequence });
-				case 3:
-					return new OtherCertificateFormat({ schema: elementSequence });
-				case 0:
-				default:
-			}
-			
-			return element;
-		});
+				const initialTagNumber = element.idBlock.tagNumber;
+
+				if(element.idBlock.tagClass === 1)
+					return new Certificate({ schema: element });
+
+				//region Making "Sequence" from "Constructed" value
+				const elementSequence = new asn1js.Sequence({
+					value: element.valueBlock.value
+				});
+				//endregion
+
+				switch(initialTagNumber)
+				{
+					case 1:
+						return new AttributeCertificateV1({ schema: elementSequence });
+					case 2:
+						return new AttributeCertificateV2({ schema: elementSequence });
+					case 3:
+						return new OtherCertificateFormat({ schema: elementSequence });
+					case 0:
+					default:
+				}
+
+				return element;
+			});
+		}
 		//endregion
 	}
 	//**********************************************************************************

--- a/src/SignedData.js
+++ b/src/SignedData.js
@@ -438,9 +438,11 @@ export default class SignedData
 			return Promise.reject("Unable to get signer index from input parameters");
 		}
 		//endregion
-		
+
+		const certificates = (this.certificates || []).length ? this.certificates : trustedCerts;
+
 		//region Check that certificates field was included in signed data
-		if(("certificates" in this) === false)
+		if(!certificates)
 		{
 			if(extendedMode)
 			{
@@ -463,7 +465,7 @@ export default class SignedData
 		{
 			sequence = sequence.then(() =>
 			{
-				for(const certificate of this.certificates)
+				for(const certificate of certificates)
 				{
 					if((certificate instanceof Certificate) === false)
 						continue;
@@ -494,11 +496,11 @@ export default class SignedData
 		else // Find by SubjectKeyIdentifier
 		{
 			sequence = sequence.then(() =>
-				Promise.all(Array.from(this.certificates.filter(certificate => (certificate instanceof Certificate)), certificate =>
+				Promise.all(Array.from(certificates.filter(certificate => (certificate instanceof Certificate)), certificate =>
 					crypto.digest({ name: "sha-1" }, new Uint8Array(certificate.subjectPublicKeyInfo.subjectPublicKey.valueBlock.valueHex)))
 				).then(results =>
 				{
-					for(const [index, certificate] of this.certificates.entries())
+					for(const [index, certificate] of certificates.entries())
 					{
 						if((certificate instanceof Certificate) === false)
 							continue;


### PR DESCRIPTION
PKI.js currently supports signing SignedData values with detached certificates, but it doesn't support verification. This PR adds that functionality.

See [`SignedData` in RFC 5652](https://tools.ietf.org/html/rfc5652#section-5.1):

```
      SignedData ::= SEQUENCE {
        version CMSVersion,
        digestAlgorithms DigestAlgorithmIdentifiers,
        encapContentInfo EncapsulatedContentInfo,
        certificates [0] IMPLICIT CertificateSet OPTIONAL,
        crls [1] IMPLICIT RevocationInfoChoices OPTIONAL,
        signerInfos SignerInfos }
```

> (...) There may be fewer certificates than necessary, if it is expected that have an alternate means of obtaining necessary certificates (e.g., from a previous set of certificates).  The signer certificate MAY be included.