### PR TITLE
Use version range for runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "rollup-plugin-node-resolve": "4.0.1"
   },
   "dependencies": {
-    "asn1js": "latest",
-    "bytestreamjs": "latest",
-    "pvutils": "latest"
+    "asn1js": "^2.0.26",
+    "bytestreamjs": "^1.0.29",
+    "pvutils": "^1.0.17"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
When a project has a dependency (either directly or transiently) on `pkijs` _and_ on one or more of `pkijs`'s own dependencies (either directly or transiently), [`yarn`](https://yarnpkg.com) will show a warning on dependency installation.

For example:
```
warning Pattern ["asn1js@latest"] is trying to unpack in the same destination "/Users/cameronhunter/Library/Caches/Yarn/v4/npm-asn1js-2.0.22-add7ab817372da160bd5c51aa19247d749c3288c/node_modules/asn1js" as pattern ["asn1js@^2.0.22"]. This could result in non-deterministic behavior, skipping.
```

This is because of `pkijs`'s usage of `latest` as the dependency version string in `package.json`. This is easily fixed by declaring a version instead of using `latest`.

This pull-request fixes the issue reported in #250 