### PR TITLE
Expose ECDH private key generated by EnvelopedData.encrypt()

### DIFF
--- a/src/EnvelopedData.js
+++ b/src/EnvelopedData.js
@@ -932,6 +932,8 @@ export default class EnvelopedData
 				 */
 				_this.recipientInfos[index].value.recipientEncryptedKeys.encryptedKeys[0].encryptedKey = new asn1js.OctetString({ valueHex: result });
 				//endregion
+
+				return {ecdhPrivateKey};
 			}, error =>
 				Promise.reject(error)
 			);


### PR DESCRIPTION
[`EnvelopedData.encrypt()` generates an ephemeral ECDH key pair](https://github.com/PeculiarVentures/PKI.js/blob/1a2e766d4ab9535dc6d754008d8cb4a2ae96ac3d/src/EnvelopedData.js#L791-L802) but its private key (`ecdhPrivateKey`) is lost when the function returns. This means you can't receive messages encrypted with a DH shared key that uses `ecdhPublicKey`.

I'm implementing a protocol where Alice and Bob are constantly generating DH keys, so they both need to persist DH private keys to be able to decrypt the next message or two (those private keys will then be securely deleted once they're no longer needed).

So that means I need to be able to set or retrieve the ECDH private key used by `EnvelopedData.encrypt()`, and the latter is easier to implement with the current code.