### PR TITLE
Compare recipientCertificate's curve in EnvelopedData using duck typing

### DIFF
--- a/src/EnvelopedData.js
+++ b/src/EnvelopedData.js
@@ -760,7 +760,7 @@ export default class EnvelopedData
 			{
 				const curveObject = _this.recipientInfos[index].value.recipientCertificate.subjectPublicKeyInfo.algorithm.algorithmParams;
 				
-				if((curveObject instanceof asn1js.ObjectIdentifier) === false)
+				if(curveObject.constructor.name !== "ObjectIdentifier")
 					return Promise.reject(`Incorrect "recipientCertificate" for index ${index}`);
 				
 				const curveOID = curveObject.valueBlock.toString();
@@ -1259,9 +1259,9 @@ export default class EnvelopedData
 					
 				const curveObject = decryptionParameters.recipientCertificate.subjectPublicKeyInfo.algorithm.algorithmParams;
 					
-				if((curveObject instanceof asn1js.ObjectIdentifier) === false)
-					return Promise.reject(`Incorrect "recipientCertificate" for index ${index}`);
 					
+				if(curveObject.constructor.name !== "ObjectIdentifier")
+					return Promise.reject(`BADGER decrypt Incorrect "recipientCertificate" for index ${index}`);
 				curveOID = curveObject.valueBlock.toString();
 					
 				switch(curveOID)

--- a/src/EnvelopedData.js
+++ b/src/EnvelopedData.js
@@ -1261,7 +1261,7 @@ export default class EnvelopedData
 					
 					
 				if(curveObject.constructor.name !== "ObjectIdentifier")
-					return Promise.reject(`BADGER decrypt Incorrect "recipientCertificate" for index ${index}`);
+					return Promise.reject(`Incorrect "recipientCertificate" for index ${index}`);
 				curveOID = curveObject.valueBlock.toString();
 					
 				switch(curveOID)

--- a/src/EnvelopedData.js
+++ b/src/EnvelopedData.js
@@ -760,7 +760,7 @@ export default class EnvelopedData
 			{
 				const curveObject = _this.recipientInfos[index].value.recipientCertificate.subjectPublicKeyInfo.algorithm.algorithmParams;
 				
-				if(curveObject.constructor.name !== "ObjectIdentifier")
+				if(curveObject.constructor.blockName() !== asn1js.ObjectIdentifier.blockName())
 					return Promise.reject(`Incorrect "recipientCertificate" for index ${index}`);
 				
 				const curveOID = curveObject.valueBlock.toString();
@@ -1260,7 +1260,7 @@ export default class EnvelopedData
 				const curveObject = decryptionParameters.recipientCertificate.subjectPublicKeyInfo.algorithm.algorithmParams;
 					
 					
-				if(curveObject.constructor.name !== "ObjectIdentifier")
+				if(curveObject.constructor.blockName() !== asn1js.ObjectIdentifier.blockName())
 					return Promise.reject(`Incorrect "recipientCertificate" for index ${index}`);
 				curveOID = curveObject.valueBlock.toString();
 					


### PR DESCRIPTION
`EnvelopedData.decrypt()` uses `instanceof` to check that a value in the `recipientCertificate` is of type `asn1js.ObjectIdentifier`, but that breaks when `asn1js.ObjectIdentifier` isn't the exact same value. For example, when the `recipientCertificate` has just been deserialized [1], you'd get an error like `Incorrect "recipientCertificate" for index 0`.

I'm proposing to fix this by replacing `instanceof` with a more lax, duck typing-like check like the one adopted in #234. I considered checking whether using `peerDependencies` would solve this kind of problems more generally,  but decided against it because it felt like a more invasive change and I was afraid I might inadvertently break something.

Also made the same change to `EnvelopedData.encrypt()` for consistency, but I personally haven't experienced any issue with its use there, so I'm happy to undo it there.

--

[1] Here's how to reproduce it:
```typescript

import * as asn1js from 'asn1js';
import * as pkijs from 'pkijs';

const cryptoEngine = pkijs.getCrypto() as SubtleCrypto;

test('PKI.js serial number bug', async () => {
  const dhKeyPair = await generateECDHKeyPair();
  const dhCertificate = await makeCertificate(dhKeyPair);

  const envelopedData = new pkijs.EnvelopedData();
  envelopedData.addRecipientByCertificate(dhCertificate, {}, 2);
  await envelopedData.encrypt(
    // @ts-ignore
    { name: 'AES-GCM', length: 128 },
    new ArrayBuffer(0),
  );

  const privateKeyDer = await cryptoEngine.exportKey('pkcs8', dhKeyPair.privateKey);
  // THIS WORKS. But only because we're using the exact same certificate value used to encrypt it.
  expect(
    await envelopedData.decrypt(0, {
      recipientCertificate: dhCertificate,
      recipientPrivateKey: privateKeyDer,
    }),
  ).toHaveProperty('byteLength', 0);

  // Now, let's test the same thing, but pretend we're loading the certificate from disk.
  const envelopedDataSerialized = envelopedData.toSchema().toBER(false);
  const envelopedDataDeserialized = new pkijs.EnvelopedData({
    schema: deserializeDer(envelopedDataSerialized),
  });
  const dhCertSerialized = dhCertificate.toSchema(true).toBER(false);
  const dhCertDeserialized = new pkijs.Certificate({ schema: deserializeDer(dhCertSerialized) });
  const actualPlaintext = await envelopedDataDeserialized.decrypt(0, {
    recipientCertificate: dhCertDeserialized,   // <--- THIS BREAKS
    // recipientCertificate: dhCertificate,     // <--- AGAIN, THIS WORKS AS SHOWN ABOVE
    recipientPrivateKey: privateKeyDer,
  });
  expect(actualPlaintext).toHaveProperty('byteLength', 0);
});

async function makeCertificate(subjectKeyPair: CryptoKeyPair): Promise<pkijs.Certificate> {
  const pkijsCert = new pkijs.Certificate({
    serialNumber: new asn1js.Integer({ value: 1234567 }),
    version: 2, // 2 = v3
  });

  // tslint:disable-next-line:no-object-mutation
  pkijsCert.notBefore.value = new Date();
  // tslint:disable-next-line:no-object-mutation
  const tomorrow = new Date();
  tomorrow.setDate(tomorrow.getDate() + 1);
  pkijsCert.notAfter.value = tomorrow;

  pkijsCert.subject.typesAndValues.push(
    new pkijs.AttributeTypeAndValue({
      type: '2.5.4.3',
      value: new asn1js.BmpString({ value: 'John Smith' }),
    }),
  );

  pkijsCert.issuer.typesAndValues.push(
    new pkijs.AttributeTypeAndValue({
      type: '2.5.4.3',
      value: new asn1js.BmpString({ value: 'John Smith' }),
    }),
  );

  await pkijsCert.subjectPublicKeyInfo.importKey(subjectKeyPair.publicKey);

  const issuerKeyPair = await generateRSAKeyPair();
  await pkijsCert.sign(issuerKeyPair.privateKey);

  return pkijsCert;
}

function deserializeDer(derValue: ArrayBuffer): asn1js.LocalBaseBlock {
  const asn1Value = asn1js.fromBER(derValue);
  if (asn1Value.offset === -1) {
    throw new Error('Value is not DER-encoded');
  }
  return asn1Value.result;
}

export async function generateRSAKeyPair(): Promise<CryptoKeyPair> {
  const algorithm = pkijs.getAlgorithmParameters('RSA-PSS', 'generatekey');
  // tslint:disable-next-line:no-object-mutation
  (algorithm.algorithm.hash as Algorithm).name = 'SHA-256';
  // tslint:disable-next-line:no-object-mutation
  algorithm.algorithm.modulusLength = 2048;

  return cryptoEngine.generateKey(algorithm.algorithm, true, algorithm.usages);
}

export async function generateECDHKeyPair(): Promise<CryptoKeyPair> {
  return cryptoEngine.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, [
    'deriveBits',
    'deriveKey',
  ]);
}

```