### PR TITLE
Allow changing salt length for EncryptedContentInfo #300

### DIFF
--- a/src/AuthenticatedSafe.js
+++ b/src/AuthenticatedSafe.js
@@ -408,6 +408,9 @@ export default class AuthenticatedSafe
 						
 						const currentParameters = parameters.safeContents[index];
 						currentParameters.contentToEncrypt = content.value.toSchema().toBER(false);
+
+						if ('saltLength' in parameters)
+							currentParameters.saltLength = parameters.saltLength;
 						//endregion
 						
 						//region Encrypt CMS EncryptedData using password

--- a/src/CryptoEngine.js
+++ b/src/CryptoEngine.js
@@ -1839,7 +1839,8 @@ export default class CryptoEngine
 		const ivView = new Uint8Array(ivBuffer);
 		this.getRandomValues(ivView);
 		
-		const saltBuffer = new ArrayBuffer(64);
+		const saltLength = 'saltLength' in parameters ? parameters.saltLength : 64;
+		const saltBuffer = new ArrayBuffer(saltLength);
 		const saltView = new Uint8Array(saltBuffer);
 		this.getRandomValues(saltView);
 		


### PR DESCRIPTION
This simply allows passing `saltLength` in parameters when encrypting EncryptedContentInfo.
This allows changing salt to 8 bytes which is useful when creating P12/PFX that need to be opened in Windows (as described in #300).

The existing behavior is unchanged (salt is 64 bytes by default).