### PR TITLE
Fix support for RSAES-PKCS1-V1_5 certificate signatures

### DIFF
--- a/src/CryptoEngine.js
+++ b/src/CryptoEngine.js
@@ -2296,7 +2296,7 @@ export default class CryptoEngine
 		//endregion
 		
 		//region Fill internal structures base on "privateKey" and "hashAlgorithm"
-		switch(privateKey.algorithm.name.toUpperCase())
+		switch(parameters.algorithm.name.toUpperCase())
 		{
 			case "RSASSA-PKCS1-V1_5":
 			case "ECDSA":


### PR DESCRIPTION
There is a regression between 2.1.91 and 2.1.92 and all later versions when trying to sign data using a RSAES-PKCS1-V1_5 ~public~private key (which must be performed with the RSASSA-PKCS1-V1_5 algorithm).

- 2.1.91 works
- 2.1.92 fails with
```
TypeError: Cannot set properties of undefined (setting 'name')
    at CryptoEngine.getSignatureParameters (/repos/xxx/node_modules/pkijs/src/CryptoEngine.js:2294:3)
    ...
```
- 2.1.93 and all later versions fail with rejection `"Unsupported signature algorithm: RSAES-PKCS1-v1_5"`

After tracing the issue in 2.2.2, it seems that the problem is currently that `CryptoEngine.getAlgorithmParameters:2299` should switch on `parameters.algorithm.name.toUpperCase()` rather than `privateKey.algorithm.name.toUpperCase()`.