### PR TITLE
Fix splice usage pattern

### DIFF
--- a/src/CertificateChainValidationEngine.ts
+++ b/src/CertificateChainValidationEngine.ts
@@ -314,7 +314,7 @@ export class CertificateChainValidationEngine {
     }
 
     // Now perform certificate verification checking
-    for (let i = 0; i < result.length; i++) {
+    for (let i = result.length - 1; i >= 0; i--) {
       try {
         const verificationResult = await certificate.verify(result[i], crypto);
         if (verificationResult === false)
@@ -813,7 +813,7 @@ export class CertificateChainValidationEngine {
     //#endregion
 
     //#region Exclude certificate paths not ended with "trusted roots"
-    for (let i = 0; i < result.length; i++) {
+    for (let i = result.length - 1; i >= 0; i--) {
       let found = false;
 
       for (let j = 0; j < (result[i]).length; j++) {
@@ -832,7 +832,6 @@ export class CertificateChainValidationEngine {
 
       if (!found) {
         result.splice(i, 1);
-        i = 0;
       }
     }
 

--- a/src/SignedCertificateTimestamp.ts
+++ b/src/SignedCertificateTimestamp.ts
@@ -421,19 +421,21 @@ export async function verifySCTsForCertificate(certificate: Certificate, issuerC
   const stream = new bs.SeqStream();
 
   //#region Remove certificate extension
-  for (let i = 0; certificate.extensions && i < certificate.extensions.length; i++) {
-    switch (certificate.extensions[i].extnID) {
-      case id_SignedCertificateTimestampList:
-        {
-          parsedValue = certificate.extensions[i].parsedValue;
+  if (certificate.extensions) {
+    for (let i = certificate.extensions.length - 1; i >=0; i--) {
+      switch (certificate.extensions[i].extnID) {
+        case id_SignedCertificateTimestampList:
+          {
+            parsedValue = certificate.extensions[i].parsedValue;
 
-          if (!parsedValue || parsedValue.timestamps.length === 0)
-            throw new Error("Nothing to verify in the certificate");
+            if (!parsedValue || parsedValue.timestamps.length === 0)
+              throw new Error("Nothing to verify in the certificate");
 
-          certificate.extensions.splice(i, 1);
-        }
-        break;
-      default:
+            certificate.extensions.splice(i, 1);
+          }
+          break;
+        default:
+      }
     }
   }
   //#endregion


### PR DESCRIPTION
You should not modify(`splice`) the array in ascending order while iterating over it using a for loop. 
Affect modules: 
`CertificateChainValidationEngine`
`SignedCertificateTimestamp`
