### PR TITLE
Improve computation speed for makePKCS12B2Key

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@noble/hashes": "^1.4.0",
     "asn1js": "^3.0.5",
     "bytestreamjs": "^2.0.0",
     "pvtsutils": "^1.3.2",

--- a/test/pkcs12SimpleExample.spec.ts
+++ b/test/pkcs12SimpleExample.spec.ts
@@ -1,6 +1,8 @@
 import * as assert from "assert";
 import "./utils";
 import * as example from "./pkcs12SimpleExample";
+import { CryptoEngine } from "../src";
+import { Convert } from "pvtsutils";
 
 context("PKCS#12 Simple Example", () => {
   const password = "12345567890";
@@ -46,5 +48,17 @@ context("PKCS#12 Simple Example", () => {
   it("Making OpenSSL-like PKCS#12 Data", async () => {
     const pfx = await example.openSSLLike(password);
     await example.parsePKCS12(pfx, password);
+  });
+
+  it("Speed test for stampDataWithPassword", async () => {
+    const engine = new CryptoEngine({ name: "node", crypto: crypto });
+    const encData = await engine.stampDataWithPassword({
+      password: Convert.FromUtf8String(password),
+      salt: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+      iterationCount: 6e5,
+      hashAlgorithm: "SHA-256",
+      contentToStamp: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+    });
+    assert.strictEqual(Convert.ToBase64(encData), "4iwFEULKTVUoMs1fF6EQ9q+vhr+DFeT10IRnVVSqKdg=");
   });
 });

--- a/test/pkcs12SimpleExample.spec.ts
+++ b/test/pkcs12SimpleExample.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as crypto from "crypto";
 import "./utils";
 import * as example from "./pkcs12SimpleExample";
 import { CryptoEngine } from "../src";
@@ -51,7 +52,7 @@ context("PKCS#12 Simple Example", () => {
   });
 
   it("Speed test for stampDataWithPassword", async () => {
-    const engine = new CryptoEngine({ name: "node", crypto: crypto });
+    const engine = new CryptoEngine({ name: "node", crypto: crypto.webcrypto as globalThis.Crypto });
     const encData = await engine.stampDataWithPassword({
       password: Convert.FromUtf8String(password),
       salt: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@noble/hashes@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
This pull request includes the following changes:

- Added a speed test for the `stampDataWithPassword` function in the `pkcs12SimpleExample.spec.ts` file.
- Updated the `makePKCS12B2Key` function to use the `@noble/hashes` dependency for improved computation speed.
- Added the `@noble/hashes` dependency to the `package.json` file.

These changes aim to optimize the computation speed of the `makePKCS12B2Key` function by utilizing the `@noble/hashes` library. Additionally, a speed test has been added to ensure the desired performance improvements have been achieved.

The new implementation of `makePKCS12B2Key` with SHA-256 completes 600K iterations in 2 seconds.