### PR TITLE
Fix password transformation for characters with char codes greater than 255

### DIFF
--- a/test/pkcs12SimpleExample.spec.ts
+++ b/test/pkcs12SimpleExample.spec.ts
@@ -46,9 +46,23 @@ context("PKCS#12 Simple Example", () => {
     await example.certificatePrivacy(password);
   });
 
-  it("Making OpenSSL-like PKCS#12 Data", async () => {
-    const pfx = await example.openSSLLike(password);
-    await example.parsePKCS12(pfx, password);
+  context("Making OpenSSL-like PKCS#12 Data", () => {
+    it("ASCII", async () => {
+      const pfx = await example.openSSLLike(password);
+      await example.parsePKCS12(pfx, password);
+    });
+
+    it("UTF-8", async () => {
+      const password = "пароль";
+      const pfx = await example.openSSLLike(password);
+      await example.parsePKCS12(pfx, password);
+    });
+
+    it("Binary", async () => {
+      const password = "\x04\xff\x20\x21"; // decode/encode -> [ 4, 239, 191, 189, 32, 33 ]
+      const pfx = await example.openSSLLike(password);
+      await example.parsePKCS12(pfx, password);
+    });
   });
 
   it("Speed test for stampDataWithPassword", async () => {


### PR DESCRIPTION
This pull request fixes an issue where the password transformation did not support characters with char codes greater than 255. The previous implementation used a null-terminated UCS-2 encoded string, which caused incorrect transformation for such characters. This PR updates the password transformation to correctly handle characters with char codes greater than 255 by using a byte array and encoding the password as UTF-8.