### PR TITLE
Support `exactOptionalPropertyTypes` in `tsconfig`

### DIFF
--- a/src/PublicKeyInfo.ts
+++ b/src/PublicKeyInfo.ts
@@ -25,7 +25,7 @@ export interface IPublicKeyInfo {
   /**
    * Parsed public key value
    */
-  parsedKey?: ECPublicKey | RSAPublicKey;
+  parsedKey?: ECPublicKey | RSAPublicKey | undefined;
 }
 export type PublicKeyInfoParameters = PkiObjectParameters & Partial<IPublicKeyInfo> & { json?: JsonWebKey; };
 


### PR DESCRIPTION
PKI.js is not currently compatible with projects that have `exactOptionalPropertyTypes` set to `true` in their `tsconfig.json`. Below is the specific type error. This PR fixes this type error.

```
node_modules/pkijs/build/index.d.ts:1717:15 - error TS2420: Class 'PublicKeyInfo' incorrectly implements interface 'IPublicKeyInfo'.
  Types of property 'parsedKey' are incompatible.
    Type 'ECPublicKey | RSAPublicKey | undefined' is not assignable to type 'ECPublicKey | RSAPublicKey'.
      Type 'undefined' is not assignable to type 'ECPublicKey | RSAPublicKey'.

1717 declare class PublicKeyInfo extends PkiObject implements IPublicKeyInfo {
```

