### PR TITLE
Support automatic detection of crypto for node 19 and above

### DIFF
--- a/src/CryptoEngine/CryptoEngineInit.ts
+++ b/src/CryptoEngine/CryptoEngineInit.ts
@@ -13,11 +13,17 @@ export function initCryptoEngine() {
 
       common.setEngine(engineName, new CryptoEngine({ name: engineName, crypto: crypto }));
     }
-  } else if (typeof crypto !== "undefined" && "webcrypto" in crypto) {
-    // NodeJS ^15
-    const name = "NodeJS ^15";
-    const nodeCrypto = (crypto as any).webcrypto as Crypto;
-    common.setEngine(name, new CryptoEngine({ name, crypto: nodeCrypto }));
+  } else if (typeof crypto !== "undefined") {
+    if ("webcrypto" in crypto) {
+      // NodeJS ^15
+      const name = "NodeJS ^15";
+      const nodeCrypto = (crypto as any).webcrypto as Crypto;
+      common.setEngine(name, new CryptoEngine({ name, crypto: nodeCrypto }));
+    } else if ("subtle" in crypto) {
+      // NodeJS ^19
+      const name = "NodeJS ^19";
+      common.setEngine(name, new CryptoEngine({ name, crypto }));
+    }
   }
 
 }


### PR DESCRIPTION
Closes #414 

Since Node 19 `globalThis.crypto` now contains an instance to `Crypto`. This is still true in Node 22. Prior to Node 19 (eg in Node 18) this it was `globalThis.crypto.webcrypto`. Note that in Node 18, `globalThis.crypto` is not an instance of `Crypto` but contains both a `subtle` member and a `webcrypto` member.

See https://nodejs.org/docs/latest-v19.x/api/webcrypto.html#web-crypto-api

This isn't caught by tests as the engine gets initialized separately

https://github.com/PeculiarVentures/PKI.js/blob/06f154a632fcd695592bf9091e7d6c4cb0c1a95a/test/utils.ts#L53-L59
