### PR TITLE
OCSP: singleExtensions must be [1] EXPLICIT in SingleResponse

### DIFF
--- a/src/SingleResponse.ts
+++ b/src/SingleResponse.ts
@@ -274,8 +274,12 @@ export class SingleResponse extends PkiObject implements ISingleResponse {
     }
 
     if (this.singleExtensions) {
-      outputArray.push(new asn1js.Sequence({
-        value: Array.from(this.singleExtensions, o => o.toSchema())
+      outputArray.push(new asn1js.Constructed({
+        idBlock: {
+          tagClass: 3, // CONTEXT-SPECIFIC
+          tagNumber: 1 // [1]
+        },
+        value: [new asn1js.Sequence({ value: Array.from(this.singleExtensions, o => o.toSchema()) })]
       }));
     }
 

--- a/test/ocspResponseComplexExample.ts
+++ b/test/ocspResponseComplexExample.ts
@@ -41,6 +41,15 @@ export async function createOCSPResp(hashAlg: string, signAlg: string): Promise<
     },
   }); // status - success
   response.thisUpdate = new Date();
+  response.nextUpdate = new Date(new Date().getTime() + 24 * 60 * 60 * 1000); // Next day
+  const archiveCutoffDate = new Date(Date.now() - 7 * 365 * 24 * 60 * 60 * 1000); // 7 years ago
+  response.singleExtensions = [
+    new pkijs.Extension({
+      extnID: "1.3.6.1.5.5.7.48.1.6", // id-pkix-ocsp-archive-cutoff
+      critical: false,
+      extnValue: (new asn1js.GeneralizedTime({ valueDate: archiveCutoffDate })).toBER(false)
+    })
+  ];
 
   ocspBasicResp.tbsResponseData.responses.push(response);
 


### PR DESCRIPTION
Encode `SingleResponse.singleExtensions` as `[1] EXPLICIT` per RFC 6960 (Section 4.2.1).
This fixes schema mismatch in BasicOCSPResponse parsing.

Closes #452

cc @microshine - thank you for maintaining PKI.js!