### PR TITLE
Don't mutate extensions in `verifySCTsForCertificate`

### DIFF
--- a/test/verifySCTsExample.ts
+++ b/test/verifySCTsExample.ts
@@ -88,6 +88,11 @@ export async function verifySCTs(): Promise<boolean[]> {
   const certificate = pkijs.Certificate.fromBER(certBuffer);
   const issuer = pkijs.Certificate.fromBER(issuerBuffer);
 
+  // Verify SCTs individually
+  for (let i = 0; i < 3; i++) {
+    await pkijs.verifySCTsForCertificate(certificate, issuer, logs, i);
+  }
+  // Verify all SCTs
   return pkijs.verifySCTsForCertificate(certificate, issuer, logs, -1);
 }
 
@@ -175,5 +180,10 @@ export async function verifySCTsWithRSA(): Promise<boolean[]> {
   const certificate = pkijs.Certificate.fromBER(certBuffer);
   const issuer = pkijs.Certificate.fromBER(issuerBuffer);
 
+  // Verify SCTs individually
+  for (let i = 0; i < 3; i++) {
+    await pkijs.verifySCTsForCertificate(certificate, issuer, rsaLogs, i);
+  }
+  // Verify all SCTs
   return pkijs.verifySCTsForCertificate(certificate, issuer, rsaLogs, -1);
 }


### PR DESCRIPTION
To allow the function to be called multiple times (e.g. when verifying SCTs individually), it's necessary to leave the extensions array intact for the next call to `verifySCTsForCertificate`.