### PR TITLE
Emit GCMParameters SEQUENCE for AES-GCM AlgorithmIdentifier (RFC 5084)

### DIFF
--- a/src/CryptoEngine/CryptoEngine.ts
+++ b/src/CryptoEngine/CryptoEngine.ts
@@ -8,6 +8,7 @@ import { PublicKeyInfo } from "../PublicKeyInfo";
 import { PrivateKeyInfo } from "../PrivateKeyInfo";
 import { AlgorithmIdentifier } from "../AlgorithmIdentifier";
 import { EncryptedContentInfo } from "../EncryptedContentInfo";
+import { GCMParams } from "../GCMParams";
 import { IRSASSAPSSParams, RSASSAPSSParams } from "../RSASSAPSSParams";
 import { PBKDF2Params } from "../PBKDF2Params";
 import { PBES2Params } from "../PBES2Params";
@@ -1506,8 +1507,10 @@ export class CryptoEngine extends AbstractCryptoEngine {
 
     //#region Initial variables
 
-    // TODO Should we reuse iv from parameters.contentEncryptionAlgorithm or use it's length for ivBuffer?
-    const ivBuffer = new ArrayBuffer(16); // For AES we need IV 16 bytes long
+    // AES-GCM uses a 12-byte nonce per NIST SP 800-38D §8.2.1 / RFC 5084.
+    // Other AES modes use a 16-byte IV.
+    const isAesGcm = parameters.contentEncryptionAlgorithm.name === "AES-GCM";
+    const ivBuffer = new ArrayBuffer(isAesGcm ? 12 : 16);
     const ivView = new Uint8Array(ivBuffer);
     this.getRandomValues(ivView);
 
@@ -1572,7 +1575,14 @@ export class CryptoEngine extends AbstractCryptoEngine {
       }),
       encryptionScheme: new AlgorithmIdentifier({
         algorithmId: contentEncryptionOID,
-        algorithmParams: new asn1js.OctetString({ valueHex: ivBuffer })
+        // RFC 5084 §3.2 requires AES-GCM AlgorithmIdentifier parameters to be
+        // a GCMParameters SEQUENCE (nonce + optional ICV length), not a bare
+        // OCTET STRING. WebCrypto AES-GCM emits a 128-bit / 16-byte ICV by
+        // default; advertise it explicitly rather than relying on the schema
+        // default of 12. Other ciphers keep the legacy OCTET-STRING IV.
+        algorithmParams: isAesGcm
+          ? new GCMParams({ nonce: ivBuffer, icvLen: 16 }).toSchema()
+          : new asn1js.OctetString({ valueHex: ivBuffer })
       })
     });
 
@@ -1620,7 +1630,28 @@ export class CryptoEngine extends AbstractCryptoEngine {
 
     const contentEncryptionAlgorithm = this.getAlgorithmByOID(pbes2Parameters.encryptionScheme.algorithmId, true);
 
-    const ivBuffer = pbes2Parameters.encryptionScheme.algorithmParams.valueBlock.valueHex;
+    // AES-GCM parameters are a GCMParameters SEQUENCE per RFC 5084 §3.2.
+    // Older pkijs output emitted a bare OCTET STRING; fall back to that
+    // shape so previously-produced blobs remain decryptable.
+    const isAesGcm = contentEncryptionAlgorithm.name === "AES-GCM";
+    let ivBuffer: ArrayBuffer;
+    let gcmTagLengthBits: number | undefined;
+    if (isAesGcm) {
+      try {
+        const gcmParams = new GCMParams({
+          schema: pbes2Parameters.encryptionScheme.algorithmParams
+        });
+        ivBuffer = gcmParams.nonce;
+        // RFC 5084 default is 12; WebCrypto default is 16.
+        gcmTagLengthBits = ((gcmParams.icvLen ?? 12) * 8);
+      } catch {
+        // Legacy fallback: params encoded as bare OCTET STRING.
+        // No explicit ICV length available; let WebCrypto use its default (128 bits).
+        ivBuffer = pbes2Parameters.encryptionScheme.algorithmParams.valueBlock.valueHex;
+      }
+    } else {
+      ivBuffer = pbes2Parameters.encryptionScheme.algorithmParams.valueBlock.valueHex;
+    }
     const ivView = new Uint8Array(ivBuffer);
 
     const saltBuffer = pbkdf2Params.salt.valueBlock.valueHex;
@@ -1665,12 +1696,14 @@ export class CryptoEngine extends AbstractCryptoEngine {
     const dataBuffer = parameters.encryptedContentInfo.getEncryptedContent();
     //#endregion
 
-    return this.decrypt({
+    const decryptParams: Algorithm & { iv: Uint8Array; tagLength?: number } = {
       name: contentEncryptionAlgorithm.name,
       iv: ivView
-    },
-      result,
-      dataBuffer);
+    };
+    if (isAesGcm && gcmTagLengthBits !== undefined) {
+      decryptParams.tagLength = gcmTagLengthBits;
+    }
+    return this.decrypt(decryptParams, result, dataBuffer);
     //#endregion
   }
 

--- a/src/CryptoEngine/CryptoEngine.ts
+++ b/src/CryptoEngine/CryptoEngine.ts
@@ -8,6 +8,7 @@ import { PublicKeyInfo } from "../PublicKeyInfo";
 import { PrivateKeyInfo } from "../PrivateKeyInfo";
 import { AlgorithmIdentifier } from "../AlgorithmIdentifier";
 import { EncryptedContentInfo } from "../EncryptedContentInfo";
+import { GCMParams } from "../GCMParams";
 import { IRSASSAPSSParams, RSASSAPSSParams } from "../RSASSAPSSParams";
 import { PBKDF2Params } from "../PBKDF2Params";
 import { PBES2Params } from "../PBES2Params";
@@ -1600,7 +1601,9 @@ export class CryptoEngine extends AbstractCryptoEngine {
     //#region Initial variables
 
     // TODO Should we reuse iv from parameters.contentEncryptionAlgorithm or use it's length for ivBuffer?
-    const ivBuffer = new ArrayBuffer(16); // For AES we need IV 16 bytes long
+    // AES-GCM takes a 12-byte nonce per RFC 5084, other AES modes a 16-byte IV
+    const isAesGcm = parameters.contentEncryptionAlgorithm.name.toUpperCase() === "AES-GCM";
+    const ivBuffer = new ArrayBuffer(isAesGcm ? 12 : 16);
     const ivView = new Uint8Array(ivBuffer);
     this.getRandomValues(ivView);
 
@@ -1664,7 +1667,11 @@ export class CryptoEngine extends AbstractCryptoEngine {
       }),
       encryptionScheme: new AlgorithmIdentifier({
         algorithmId: contentEncryptionOID,
-        algorithmParams: new asn1js.OctetString({ valueHex: ivBuffer })
+        // AES-GCM parameters are a GCMParameters SEQUENCE per RFC 5084, not a bare
+        // OCTET STRING; WebCrypto emits a 16-byte ICV, so state it instead of defaulting to 12
+        algorithmParams: isAesGcm
+          ? new GCMParams({ nonce: ivBuffer, icvLen: 16 }).toSchema()
+          : new asn1js.OctetString({ valueHex: ivBuffer })
       })
     });
 
@@ -1725,7 +1732,15 @@ export class CryptoEngine extends AbstractCryptoEngine {
       true
     );
 
-    const ivBuffer = pbes2Parameters.encryptionScheme.algorithmParams.valueBlock.valueHex;
+    // AES-GCM parameters are a GCMParameters SEQUENCE per RFC 5084, and carry the
+    // ICV length the tag must be read at
+    const isAesGcm = contentEncryptionAlgorithm.name.toUpperCase() === "AES-GCM";
+    const gcmParams = isAesGcm
+      ? GCMParams.fromAlgorithmParams(pbes2Parameters.encryptionScheme.algorithmParams)
+      : undefined;
+    const ivBuffer = gcmParams
+      ? gcmParams.nonce
+      : pbes2Parameters.encryptionScheme.algorithmParams.valueBlock.valueHex;
     const ivView = new Uint8Array(ivBuffer);
 
     const saltBuffer = pbkdf2Params.salt.valueBlock.valueHex;
@@ -1769,14 +1784,14 @@ export class CryptoEngine extends AbstractCryptoEngine {
     const dataBuffer = parameters.encryptedContentInfo.getEncryptedContent();
     //#endregion
 
-    return this.decrypt(
-      {
-        name: contentEncryptionAlgorithm.name,
-        iv: ivView
-      },
-      result,
-      dataBuffer
-    );
+    const decryptParams: AesGcmParams = {
+      name: contentEncryptionAlgorithm.name,
+      iv: ivView
+    };
+    if (gcmParams?.tagLength !== undefined) {
+      decryptParams.tagLength = gcmParams.tagLength;
+    }
+    return this.decrypt(decryptParams, result, dataBuffer);
     //#endregion
   }
 

--- a/src/EnvelopedData.ts
+++ b/src/EnvelopedData.ts
@@ -7,6 +7,7 @@ import { RecipientInfo, RecipientInfoJson } from "./RecipientInfo";
 import { EncryptedContentInfo, EncryptedContentInfoJson, EncryptedContentInfoSchema, EncryptedContentInfoSplit } from "./EncryptedContentInfo";
 import { Attribute, AttributeJson } from "./Attribute";
 import { AlgorithmIdentifier, AlgorithmIdentifierParameters } from "./AlgorithmIdentifier";
+import { GCMParams } from "./GCMParams";
 import { RSAESOAEPParams } from "./RSAESOAEPParams";
 import { KeyTransRecipientInfo } from "./KeyTransRecipientInfo";
 import { IssuerAndSerialNumber } from "./IssuerAndSerialNumber";
@@ -797,7 +798,10 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
    */
   public async encrypt(contentEncryptionAlgorithm: Algorithm, contentToEncrypt: ArrayBuffer, crypto = common.getCrypto(true)): Promise<(void | { ecdhPrivateKey: CryptoKey; })[]> {
     //#region Initial variables
-    const ivBuffer = new ArrayBuffer(16); // For AES we need IV 16 bytes long
+    // AES-GCM uses a 12-byte nonce per NIST SP 800-38D §8.2.1 and RFC 5084
+    // recommendation. Other AES modes use a 16-byte IV.
+    const isAesGcm = contentEncryptionAlgorithm.name === "AES-GCM";
+    const ivBuffer = new ArrayBuffer(isAesGcm ? 12 : 16);
     const ivView = new Uint8Array(ivBuffer);
     crypto.getRandomValues(ivView);
 
@@ -830,7 +834,14 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
       contentType: "1.2.840.113549.1.7.1", // "data"
       contentEncryptionAlgorithm: new AlgorithmIdentifier({
         algorithmId: contentEncryptionOID,
-        algorithmParams: new asn1js.OctetString({ valueHex: ivBuffer })
+        // RFC 5084 §3.2 requires AES-GCM AlgorithmIdentifier parameters to be
+        // a GCMParameters SEQUENCE (nonce + optional ICV length), not a bare
+        // OCTET STRING. WebCrypto AES-GCM emits a 128-bit / 16-byte ICV by
+        // default; advertise it explicitly rather than relying on the schema
+        // default of 12. Other ciphers keep the legacy OCTET-STRING IV.
+        algorithmParams: isAesGcm
+          ? new GCMParams({ nonce: ivBuffer, icvLen: 16 }).toSchema()
+          : new asn1js.OctetString({ valueHex: ivBuffer })
       }),
       encryptedContent: new asn1js.OctetString({ valueHex: encryptedContent })
     });
@@ -1545,7 +1556,28 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
     //#endregion
 
     //#region Get "initialization vector" for content encryption algorithm
-    const ivBuffer = this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams.valueBlock.valueHex;
+    // AES-GCM parameters are a GCMParameters SEQUENCE per RFC 5084 §3.2.
+    // Older pkijs output emitted a bare OCTET STRING; fall back to that
+    // shape so previously-produced blobs remain decryptable.
+    const isAesGcm = (contentEncryptionAlgorithm as any).name === "AES-GCM";
+    let ivBuffer: ArrayBuffer;
+    let gcmTagLengthBits: number | undefined;
+    if (isAesGcm) {
+      try {
+        const gcmParams = new GCMParams({
+          schema: this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams
+        });
+        ivBuffer = gcmParams.nonce;
+        // RFC 5084 default is 12; WebCrypto default is 16.
+        gcmTagLengthBits = ((gcmParams.icvLen ?? 12) * 8);
+      } catch {
+        // Legacy fallback: params encoded as bare OCTET STRING.
+        // No explicit ICV length available; let WebCrypto use its default (128 bits).
+        ivBuffer = this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams.valueBlock.valueHex;
+      }
+    } else {
+      ivBuffer = this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams.valueBlock.valueHex;
+    }
     const ivView = new Uint8Array(ivBuffer);
     //#endregion
 
@@ -1556,13 +1588,14 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
     const dataBuffer = this.encryptedContentInfo.getEncryptedContent();
     //#endregion
 
-    return crypto.decrypt(
-      {
-        name: (contentEncryptionAlgorithm as any).name,
-        iv: ivView
-      },
-      unwrappedKey,
-      dataBuffer);
+    const decryptAlgorithm: Algorithm & { iv: Uint8Array; tagLength?: number } = {
+      name: (contentEncryptionAlgorithm as any).name,
+      iv: ivView
+    };
+    if (isAesGcm && gcmTagLengthBits !== undefined) {
+      decryptAlgorithm.tagLength = gcmTagLengthBits;
+    }
+    return crypto.decrypt(decryptAlgorithm, unwrappedKey, dataBuffer);
     //#endregion
   }
 

--- a/src/EnvelopedData.ts
+++ b/src/EnvelopedData.ts
@@ -12,6 +12,7 @@ import {
 } from "./EncryptedContentInfo";
 import { Attribute, AttributeJson } from "./Attribute";
 import { AlgorithmIdentifier, AlgorithmIdentifierParameters } from "./AlgorithmIdentifier";
+import { GCMParams } from "./GCMParams";
 import { RSAESOAEPParams } from "./RSAESOAEPParams";
 import { KeyTransRecipientInfo } from "./KeyTransRecipientInfo";
 import { IssuerAndSerialNumber } from "./IssuerAndSerialNumber";
@@ -918,7 +919,9 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
     crypto = common.getCrypto(true)
   ): Promise<(void | { ecdhPrivateKey: CryptoKey })[]> {
     //#region Initial variables
-    const ivBuffer = new ArrayBuffer(16); // For AES we need IV 16 bytes long
+    // AES-GCM takes a 12-byte nonce per RFC 5084, other AES modes a 16-byte IV
+    const isAesGcm = contentEncryptionAlgorithm.name.toUpperCase() === "AES-GCM";
+    const ivBuffer = new ArrayBuffer(isAesGcm ? 12 : 16);
     const ivView = new Uint8Array(ivBuffer);
     crypto.getRandomValues(ivView);
 
@@ -961,7 +964,11 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
       contentType: "1.2.840.113549.1.7.1", // "data"
       contentEncryptionAlgorithm: new AlgorithmIdentifier({
         algorithmId: contentEncryptionOID,
-        algorithmParams: new asn1js.OctetString({ valueHex: ivBuffer })
+        // AES-GCM parameters are a GCMParameters SEQUENCE per RFC 5084, not a bare
+        // OCTET STRING; WebCrypto emits a 16-byte ICV, so state it instead of defaulting to 12
+        algorithmParams: isAesGcm
+          ? new GCMParams({ nonce: ivBuffer, icvLen: 16 }).toSchema()
+          : new asn1js.OctetString({ valueHex: ivBuffer })
       }),
       encryptedContent: new asn1js.OctetString({ valueHex: encryptedContent })
     });
@@ -1798,8 +1805,17 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
     //#endregion
 
     //#region Get "initialization vector" for content encryption algorithm
-    const ivBuffer =
-      this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams.valueBlock.valueHex;
+    // AES-GCM parameters are a GCMParameters SEQUENCE per RFC 5084, and carry the
+    // ICV length the tag must be read at
+    const isAesGcm = contentEncryptionAlgorithm.name.toUpperCase() === "AES-GCM";
+    const gcmParams = isAesGcm
+      ? GCMParams.fromAlgorithmParams(
+          this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams
+        )
+      : undefined;
+    const ivBuffer = gcmParams
+      ? gcmParams.nonce
+      : this.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams.valueBlock.valueHex;
     const ivView = new Uint8Array(ivBuffer);
     //#endregion
 
@@ -1810,14 +1826,14 @@ export class EnvelopedData extends PkiObject implements IEnvelopedData {
     const dataBuffer = this.encryptedContentInfo.getEncryptedContent();
     //#endregion
 
-    return crypto.decrypt(
-      {
-        name: (contentEncryptionAlgorithm as any).name,
-        iv: ivView
-      },
-      unwrappedKey,
-      dataBuffer
-    );
+    const decryptParams: AesGcmParams = {
+      name: (contentEncryptionAlgorithm as any).name,
+      iv: ivView
+    };
+    if (gcmParams?.tagLength !== undefined) {
+      decryptParams.tagLength = gcmParams.tagLength;
+    }
+    return crypto.decrypt(decryptParams, unwrappedKey, dataBuffer);
     //#endregion
   }
 }

--- a/src/GCMParams.ts
+++ b/src/GCMParams.ts
@@ -1,0 +1,167 @@
+import * as asn1js from "asn1js";
+import * as pvutils from "pvutils";
+import { EMPTY_STRING } from "./constants";
+import { AsnError } from "./errors";
+import { PkiObject, PkiObjectParameters } from "./PkiObject";
+import * as Schema from "./Schema";
+
+const NONCE = "nonce";
+const ICV_LEN = "icvLen";
+const CLEAR_PROPS = [NONCE, ICV_LEN];
+
+/**
+ * Default ICV (authentication tag) length in bytes, per RFC 5084 §3.2.
+ */
+const DEFAULT_ICV_LEN = 12;
+
+export interface IGCMParams {
+  /**
+   * GCM nonce (also called IV). NIST SP 800-38D §8.2.1 recommends 12 bytes.
+   */
+  nonce: ArrayBuffer;
+  /**
+   * Length of the GCM authentication tag (ICV) in bytes. RFC 5084 allows
+   * 12 | 13 | 14 | 15 | 16; default is 12.
+   */
+  icvLen?: number;
+}
+
+export interface GCMParamsJson {
+  nonce: string;
+  icvLen?: number;
+}
+
+export type GCMParamsParameters = PkiObjectParameters & Partial<IGCMParams>;
+
+/**
+ * Represents the GCMParameters structure described in
+ * [RFC5084 §3.2](https://www.rfc-editor.org/rfc/rfc5084#section-3.2). This is
+ * the AlgorithmIdentifier parameter value required for AES-GCM OIDs
+ * (`aes{128,192,256}-GCM` = `2.16.840.1.101.3.4.1.{6,26,46}`).
+ */
+export class GCMParams extends PkiObject implements IGCMParams {
+
+  public static override CLASS_NAME = "GCMParams";
+
+  public nonce!: ArrayBuffer;
+  public icvLen?: number;
+
+  /**
+   * Initializes a new instance of the {@link GCMParams} class
+   * @param parameters Initialization parameters
+   */
+  constructor(parameters: GCMParamsParameters = {}) {
+    super();
+
+    this.nonce = pvutils.getParametersValue(parameters, NONCE, GCMParams.defaultValues(NONCE));
+    if (ICV_LEN in parameters) {
+      this.icvLen = pvutils.getParametersValue(parameters, ICV_LEN, GCMParams.defaultValues(ICV_LEN));
+    }
+
+    if (parameters.schema) {
+      this.fromSchema(parameters.schema);
+    }
+  }
+
+  /**
+   * Returns default values for all class members
+   * @param memberName String name for a class member
+   * @returns Default value
+   */
+  public static override defaultValues(memberName: typeof NONCE): ArrayBuffer;
+  public static override defaultValues(memberName: typeof ICV_LEN): number;
+  public static override defaultValues(memberName: string): any {
+    switch (memberName) {
+      case NONCE:
+        return new ArrayBuffer(0);
+      case ICV_LEN:
+        return DEFAULT_ICV_LEN;
+      default:
+        return super.defaultValues(memberName);
+    }
+  }
+
+  /**
+   * @inheritdoc
+   * @asn ASN.1 schema
+   * ```asn
+   * GCMParameters ::= SEQUENCE {
+   *   aes-nonce        OCTET STRING,
+   *   aes-ICVlen       AES-GCM-ICVlen DEFAULT 12 }
+   *
+   * AES-GCM-ICVlen ::= INTEGER (12 | 13 | 14 | 15 | 16)
+   * ```
+   */
+  public static override schema(parameters: Schema.SchemaParameters<{
+    nonce?: string;
+    icvLen?: string;
+  }> = {}): Schema.SchemaType {
+    const names = pvutils.getParametersValue<NonNullable<typeof parameters.names>>(parameters, "names", {});
+
+    return (new asn1js.Sequence({
+      name: (names.blockName || EMPTY_STRING),
+      value: [
+        new asn1js.OctetString({ name: (names.nonce || EMPTY_STRING) }),
+        new asn1js.Integer({
+          name: (names.icvLen || EMPTY_STRING),
+          optional: true
+        })
+      ]
+    }));
+  }
+
+  public fromSchema(schema: Schema.SchemaType): void {
+    // Clear input data first
+    pvutils.clearProps(schema, CLEAR_PROPS);
+
+    // Check the schema is valid
+    const asn1 = asn1js.compareSchema(schema,
+      schema,
+      GCMParams.schema({
+        names: {
+          nonce: NONCE,
+          icvLen: ICV_LEN
+        }
+      })
+    );
+    AsnError.assertSchema(asn1, this.className);
+
+    // Get internal properties from parsed schema
+    this.nonce = asn1.result.nonce.valueBlock.valueHex;
+    if (ICV_LEN in asn1.result) {
+      this.icvLen = asn1.result.icvLen.valueBlock.valueDec;
+    }
+  }
+
+  public toSchema(): asn1js.Sequence {
+    //#region Create array for output sequence
+    const outputArray: any[] = [];
+
+    outputArray.push(new asn1js.OctetString({ valueHex: this.nonce }));
+
+    // Per RFC 5084, emit aes-ICVlen only when it differs from the default (12).
+    if (this.icvLen !== undefined && this.icvLen !== DEFAULT_ICV_LEN) {
+      outputArray.push(new asn1js.Integer({ value: this.icvLen }));
+    }
+    //#endregion
+
+    //#region Construct and return new ASN.1 schema for this object
+    return (new asn1js.Sequence({
+      value: outputArray
+    }));
+    //#endregion
+  }
+
+  public toJSON(): GCMParamsJson {
+    const res: GCMParamsJson = {
+      nonce: pvutils.bufferToHexCodes(this.nonce)
+    };
+
+    if (this.icvLen !== undefined && this.icvLen !== DEFAULT_ICV_LEN) {
+      res.icvLen = this.icvLen;
+    }
+
+    return res;
+  }
+
+}

--- a/src/GCMParams.ts
+++ b/src/GCMParams.ts
@@ -1,0 +1,227 @@
+import * as asn1js from "asn1js";
+import * as pvutils from "pvutils";
+import { EMPTY_BUFFER, EMPTY_STRING } from "./constants";
+import { AsnError } from "./errors";
+import { PkiObject, PkiObjectParameters } from "./PkiObject";
+import * as Schema from "./Schema";
+
+const NONCE = "nonce";
+const ICV_LEN = "icvLen";
+const CLEAR_PROPS = [NONCE, ICV_LEN];
+
+/**
+ * ICV lengths in octets permitted by AES-GCM-ICVlen, per RFC 5084 Section 3.2.
+ */
+const ICV_LENS = [12, 13, 14, 15, 16];
+
+/**
+ * Checks aes-nonce and aes-ICVlen against the value constraints of RFC 5084 Section 3.2.
+ * The ICV length reaches WebCrypto as a tag length, so an out-of-range value read off
+ * an unauthenticated AlgorithmIdentifier would weaken the tag it is meant to describe.
+ * @param nonce AES-GCM nonce
+ * @param icvLen ICV length in octets, or `undefined` where the DEFAULT applies
+ */
+function assertConstraints(nonce: ArrayBuffer, icvLen?: number): void {
+  if (nonce.byteLength === 0) {
+    throw new AsnError("Invalid GCMParameters: aes-nonce must carry at least one octet");
+  }
+
+  if (icvLen !== undefined && !ICV_LENS.includes(icvLen)) {
+    throw new AsnError(
+      `Invalid GCMParameters: aes-ICVlen ${icvLen} is outside the permitted set ${ICV_LENS.join(", ")}`
+    );
+  }
+}
+
+export interface IGCMParams {
+  /**
+   * GCM nonce (also called IV). RFC 5084 recommends a size of 12 octets.
+   */
+  nonce: ArrayBuffer;
+  /**
+   * Length of the GCM authentication tag (ICV) in octets. RFC 5084 allows
+   * 12 | 13 | 14 | 15 | 16; the DEFAULT is 12.
+   */
+  icvLen?: number;
+}
+
+export interface GCMParamsJson {
+  nonce: string;
+  icvLen?: number;
+}
+
+export type GCMParamsParameters = PkiObjectParameters & Partial<IGCMParams>;
+
+/**
+ * Represents the GCMParameters structure described in [RFC5084 Section 3.2](https://datatracker.ietf.org/doc/html/rfc5084#section-3.2)
+ */
+export class GCMParams extends PkiObject implements IGCMParams {
+  public static override CLASS_NAME = "GCMParams";
+
+  public nonce!: ArrayBuffer;
+  public icvLen?: number;
+
+  /**
+   * Initializes a new instance of the {@link GCMParams} class
+   * @param parameters Initialization parameters
+   */
+  constructor(parameters: GCMParamsParameters = {}) {
+    super();
+
+    this.nonce = pvutils.getParametersValue(parameters, NONCE, GCMParams.defaultValues(NONCE));
+    if (ICV_LEN in parameters) {
+      this.icvLen = pvutils.getParametersValue(
+        parameters,
+        ICV_LEN,
+        GCMParams.defaultValues(ICV_LEN)
+      );
+    }
+
+    if (parameters.schema) {
+      this.fromSchema(parameters.schema);
+    }
+  }
+
+  /**
+   * Returns default values for all class members
+   * @param memberName String name for a class member
+   * @returns Default value
+   */
+  public static override defaultValues(memberName: typeof NONCE): ArrayBuffer;
+  public static override defaultValues(memberName: typeof ICV_LEN): number;
+  public static override defaultValues(memberName: string): any {
+    switch (memberName) {
+      case NONCE:
+        return EMPTY_BUFFER;
+      case ICV_LEN:
+        return 12;
+      default:
+        return super.defaultValues(memberName);
+    }
+  }
+
+  /**
+   * Reads the parameters of an AES-GCM AlgorithmIdentifier, accepting the bare OCTET
+   * STRING that releases before RFC 5084 conformance emitted in place of a
+   * GCMParameters SEQUENCE
+   * @param algorithmParams Value of the AlgorithmIdentifier parameters field
+   * @returns The nonce, and the tag length in bits where the parameters carry one
+   */
+  public static fromAlgorithmParams(algorithmParams: any): {
+    nonce: ArrayBuffer;
+    tagLength?: number;
+  } {
+    if (!algorithmParams) {
+      throw new AsnError(
+        "AES-GCM AlgorithmIdentifier is missing the required GCMParameters (RFC 5084 Section 3.2)"
+      );
+    }
+
+    // A bare OCTET STRING is the pre-conformance shape and states no ICV length,
+    // which leaves WebCrypto on its own 128-bit default.
+    if (algorithmParams instanceof asn1js.OctetString) {
+      return { nonce: algorithmParams.valueBlock.valueHex };
+    }
+
+    const params = new GCMParams({ schema: algorithmParams });
+
+    return {
+      nonce: params.nonce,
+      tagLength: (params.icvLen ?? GCMParams.defaultValues(ICV_LEN)) * 8
+    };
+  }
+
+  /**
+   * @inheritdoc
+   * @asn ASN.1 schema
+   * ```asn
+   * GCMParameters ::= SEQUENCE {
+   *   aes-nonce        OCTET STRING,
+   *   aes-ICVlen       AES-GCM-ICVlen DEFAULT 12 }
+   *
+   * AES-GCM-ICVlen ::= INTEGER (12 | 13 | 14 | 15 | 16)
+   * ```
+   */
+  public static override schema(
+    parameters: Schema.SchemaParameters<{
+      nonce?: string;
+      icvLen?: string;
+    }> = {}
+  ): Schema.SchemaType {
+    const names = pvutils.getParametersValue<NonNullable<typeof parameters.names>>(
+      parameters,
+      "names",
+      {}
+    );
+
+    return new asn1js.Sequence({
+      name: names.blockName || EMPTY_STRING,
+      value: [
+        new asn1js.OctetString({ name: names.nonce || EMPTY_STRING }),
+        new asn1js.Integer({
+          name: names.icvLen || EMPTY_STRING,
+          optional: true
+        })
+      ]
+    });
+  }
+
+  public fromSchema(schema: Schema.SchemaType): void {
+    // Clear input data first
+    pvutils.clearProps(schema, CLEAR_PROPS);
+
+    // Check the schema is valid
+    const asn1 = asn1js.compareSchema(
+      schema,
+      schema,
+      GCMParams.schema({
+        names: {
+          nonce: NONCE,
+          icvLen: ICV_LEN
+        }
+      })
+    );
+    AsnError.assertSchema(asn1, this.className);
+
+    // Get internal properties from parsed schema
+    this.nonce = asn1.result.nonce.valueBlock.valueHex;
+    // An absent INTEGER means the DEFAULT applies, so clear any value this
+    // instance carried before rather than re-emitting one the input never had.
+    this.icvLen = ICV_LEN in asn1.result ? asn1.result.icvLen.valueBlock.valueDec : undefined;
+
+    assertConstraints(this.nonce, this.icvLen);
+  }
+
+  public toSchema(): asn1js.Sequence {
+    assertConstraints(this.nonce, this.icvLen);
+
+    //#region Create array for output sequence
+    const outputArray: any[] = [];
+
+    outputArray.push(new asn1js.OctetString({ valueHex: this.nonce }));
+
+    // Per RFC 5084, emit aes-ICVlen only when it differs from the default.
+    if (this.icvLen !== undefined && this.icvLen !== GCMParams.defaultValues(ICV_LEN)) {
+      outputArray.push(new asn1js.Integer({ value: this.icvLen }));
+    }
+    //#endregion
+
+    //#region Construct and return new ASN.1 schema for this object
+    return new asn1js.Sequence({
+      value: outputArray
+    });
+    //#endregion
+  }
+
+  public toJSON(): GCMParamsJson {
+    const res: GCMParamsJson = {
+      nonce: pvutils.bufferToHexCodes(this.nonce)
+    };
+
+    if (this.icvLen !== undefined && this.icvLen !== GCMParams.defaultValues(ICV_LEN)) {
+      res.icvLen = this.icvLen;
+    }
+
+    return res;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export * from "./ExtKeyUsage";
 export * from "./Extension";
 export * from "./ExtensionValueFactory";
 export * from "./Extensions";
+export * from "./GCMParams";
 export * from "./GeneralName";
 export * from "./GeneralNames";
 export * from "./GeneralSubtree";

--- a/test/gcmParams.spec.ts
+++ b/test/gcmParams.spec.ts
@@ -1,0 +1,248 @@
+import * as assert from "assert";
+import * as asn1js from "asn1js";
+import * as pvtsutils from "pvtsutils";
+import { Crypto } from "@peculiar/webcrypto";
+import * as pkijs from "../src";
+import { createSelfSignedCertificate } from "./utils";
+
+// Install a crypto engine for this test file (matches test/utils.ts pattern)
+const webcrypto = new Crypto();
+pkijs.setEngine(
+  "gcm-params-test",
+  new pkijs.CryptoEngine({ name: "gcm-params-test", crypto: webcrypto }),
+);
+
+// asn1js block-tag numbers used by the structure assertions below.
+const SEQUENCE_TAG = 16;
+
+context("GCMParams (RFC 5084 §3.2)", () => {
+  //#region Tier 1: schema round-trip
+  context("schema round-trip", () => {
+    it("encodes nonce + icvLen 16, parses back with identical values", () => {
+      const nonceBytes = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+      const original = new pkijs.GCMParams({ nonce: nonceBytes.buffer, icvLen: 16 });
+
+      const der = original.toSchema().toBER(false);
+      const parsed = new pkijs.GCMParams({ schema: asn1js.fromBER(der).result });
+
+      assert.strictEqual(pvtsutils.Convert.ToHex(parsed.nonce), pvtsutils.Convert.ToHex(nonceBytes.buffer));
+      assert.strictEqual(parsed.icvLen, 16);
+    });
+
+    it("omits icvLen from DER when value equals the RFC 5084 default (12)", () => {
+      const nonce = new Uint8Array(12).buffer;
+      const seq = new pkijs.GCMParams({ nonce, icvLen: 12 }).toSchema();
+      // SEQUENCE should contain only the OCTET STRING; the INTEGER for icvLen
+      // must be absent because 12 is the ASN.1 DEFAULT value.
+      assert.strictEqual(seq.valueBlock.value.length, 1);
+    });
+
+    it("round-trips with icvLen absent (parses as undefined)", () => {
+      const nonce = new Uint8Array(12).buffer;
+      const der = new pkijs.GCMParams({ nonce }).toSchema().toBER(false);
+      const parsed = new pkijs.GCMParams({ schema: asn1js.fromBER(der).result });
+
+      assert.strictEqual(pvtsutils.Convert.ToHex(parsed.nonce), pvtsutils.Convert.ToHex(nonce));
+      assert.strictEqual(parsed.icvLen, undefined);
+    });
+  });
+  //#endregion
+
+  //#region Tier 2: PBES2 + AES-GCM via CryptoEngine (closes #486)
+  context("PBES2 encrypt/decrypt with AES-GCM (closes #486)", () => {
+    const password = new TextEncoder().encode("test-password").buffer;
+    const contentType = "1.2.840.113549.1.7.1"; // id-data
+
+    async function encryptSample(plaintext: ArrayBuffer) {
+      const crypto = pkijs.getCrypto(true);
+      return crypto.encryptEncryptedContentInfo({
+        password,
+        // `ContentEncryptionAesGcmParams` requires `iv`, but the encrypt method
+        // generates its own nonce and ignores the one on the input. Cast to
+        // `any` to satisfy the type without supplying a throwaway IV.
+        contentEncryptionAlgorithm: { name: "AES-GCM", length: 256 } as any,
+        hmacHashAlgorithm: "SHA-256",
+        iterationCount: 1000,
+        contentType,
+        contentToEncrypt: plaintext,
+      });
+    }
+
+    it("emits inner AES-GCM AlgorithmIdentifier.algorithmParams as a SEQUENCE", async () => {
+      const plaintext = new TextEncoder().encode("hello gcm").buffer;
+      const eci = await encryptSample(plaintext);
+
+      // The outer AlgorithmIdentifier is pkcs5PBES2; unwrap to reach the inner cipher AI.
+      const pbes2 = new pkijs.PBES2Params({ schema: eci.contentEncryptionAlgorithm.algorithmParams });
+      const innerParams = pbes2.encryptionScheme.algorithmParams;
+
+      // Before the fix: innerParams was a bare OCTET STRING (tag 4).
+      // After the fix: innerParams must be a SEQUENCE (tag 16) matching GCMParameters.
+      assert.strictEqual(
+        innerParams.idBlock.tagNumber,
+        SEQUENCE_TAG,
+        "AES-GCM AlgorithmIdentifier.parameters must be a GCMParameters SEQUENCE per RFC 5084 §3.2",
+      );
+
+      const gcmParams = new pkijs.GCMParams({ schema: innerParams });
+      assert.strictEqual(gcmParams.nonce.byteLength, 12, "AES-GCM nonce should be 12 bytes (NIST SP 800-38D §8.2.1)");
+      assert.strictEqual(gcmParams.icvLen, 16, "ICV length must reflect WebCrypto's 128-bit default tag");
+    });
+
+    it("decrypt recovers the original plaintext (new-format round-trip)", async () => {
+      const plaintext = new TextEncoder().encode("hello gcm round-trip").buffer;
+      const eci = await encryptSample(plaintext);
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci,
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("legacy fallback: decrypts a blob whose params are a bare OCTET STRING", async () => {
+      const plaintext = new TextEncoder().encode("legacy gcm output").buffer;
+      const eci = await encryptSample(plaintext);
+
+      // Simulate pre-fix pkijs output by rewriting the inner algorithmParams from
+      // GCMParameters SEQUENCE back to a bare OCTET STRING carrying the same nonce.
+      // The ciphertext stays valid because it was encrypted with that exact nonce.
+      const pbes2 = new pkijs.PBES2Params({ schema: eci.contentEncryptionAlgorithm.algorithmParams });
+      const gcm = new pkijs.GCMParams({ schema: pbes2.encryptionScheme.algorithmParams });
+      pbes2.encryptionScheme.algorithmParams = new asn1js.OctetString({ valueHex: gcm.nonce });
+      eci.contentEncryptionAlgorithm.algorithmParams = pbes2.toSchema();
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci,
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("legacy fallback: decrypts an authentic pre-fix blob with 16-byte nonce", async () => {
+      // Pre-fix pkijs always generated a 16-byte IV (new ArrayBuffer(16) in
+      // encryptEncryptedContentInfo) regardless of cipher. This test reconstructs
+      // an exact pre-fix shape: 16-byte nonce inside a bare OCTET STRING, with
+      // matching ciphertext produced by WebCrypto using that same 16-byte IV.
+      const plaintext = new TextEncoder().encode("authentic pre-fix gcm blob").buffer;
+
+      const salt = new Uint8Array(64);
+      webcrypto.getRandomValues(salt);
+      const nonce16 = new Uint8Array(16);
+      webcrypto.getRandomValues(nonce16);
+      const iterationCount = 1000;
+
+      const pbkdfKey = await webcrypto.subtle.importKey(
+        "raw", new Uint8Array(password), "PBKDF2", false, ["deriveKey"],
+      );
+      const aesKey = await webcrypto.subtle.deriveKey(
+        { name: "PBKDF2", hash: "SHA-256", salt, iterations: iterationCount },
+        pbkdfKey,
+        { name: "AES-GCM", length: 256 },
+        false,
+        ["encrypt"],
+      );
+      const ciphertext = await webcrypto.subtle.encrypt(
+        { name: "AES-GCM", iv: nonce16 },
+        aesKey,
+        new Uint8Array(plaintext),
+      );
+
+      // Build the PBES2Params manually with the legacy shape: bare OCTET STRING
+      // in encryptionScheme.algorithmParams instead of a GCMParameters SEQUENCE.
+      const pbes2 = new pkijs.PBES2Params({
+        keyDerivationFunc: new pkijs.AlgorithmIdentifier({
+          algorithmId: "1.2.840.113549.1.5.12", // id-PBKDF2
+          algorithmParams: new pkijs.PBKDF2Params({
+            salt: new asn1js.OctetString({ valueHex: salt.buffer }),
+            iterationCount,
+            prf: new pkijs.AlgorithmIdentifier({
+              algorithmId: "1.2.840.113549.2.9", // hmacWithSHA256
+              algorithmParams: new asn1js.Null(),
+            }),
+          }).toSchema(),
+        }),
+        encryptionScheme: new pkijs.AlgorithmIdentifier({
+          algorithmId: "2.16.840.1.101.3.4.1.46", // aes256-GCM
+          algorithmParams: new asn1js.OctetString({ valueHex: nonce16.buffer }),
+        }),
+      });
+
+      const eci = new pkijs.EncryptedContentInfo({
+        contentType,
+        contentEncryptionAlgorithm: new pkijs.AlgorithmIdentifier({
+          algorithmId: "1.2.840.113549.1.5.13", // pkcs5PBES2
+          algorithmParams: pbes2.toSchema(),
+        }),
+        encryptedContent: new asn1js.OctetString({ valueHex: ciphertext }),
+      });
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci,
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+  });
+  //#endregion
+
+  //#region Tier 3: CMS EnvelopedData with AES-GCM (closes #287)
+  context("EnvelopedData AES-GCM emission (closes #287)", () => {
+    it("emits the inner AES-GCM AlgorithmIdentifier.algorithmParams as a SEQUENCE", async () => {
+      const plaintext = new TextEncoder().encode("hello enveloped").buffer;
+
+      // EnvelopedData.encrypt builds encryptedContentInfo regardless of whether
+      // any recipient infos are attached, so no recipient setup is needed to
+      // exercise the AlgorithmIdentifier emission path.
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      await enveloped.encrypt({ name: "AES-GCM", length: 256 } as AesKeyGenParams, plaintext);
+
+      const innerParams = enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams;
+      assert.strictEqual(
+        innerParams.idBlock.tagNumber,
+        SEQUENCE_TAG,
+        "CMS AES-GCM AlgorithmIdentifier.parameters must be a GCMParameters SEQUENCE per RFC 5084 §3.2",
+      );
+
+      const gcmParams = new pkijs.GCMParams({ schema: innerParams });
+      assert.strictEqual(gcmParams.nonce.byteLength, 12);
+      assert.strictEqual(gcmParams.icvLen, 16);
+    });
+
+    it("full round-trip via RSA-OAEP cert recipient: encrypt → BER → parse → decrypt", async () => {
+      // End-to-end proof that EnvelopedData's decrypt path correctly handles
+      // the new GCMParameters SEQUENCE — mirrors the CryptoEngine new-format
+      // round-trip but exercises the separate EnvelopedData decrypt code path.
+      const plaintext = new TextEncoder().encode("cms enveloped round-trip payload").buffer;
+      const certData = await createSelfSignedCertificate("SHA-256", "RSASSA-PKCS1-v1_5");
+
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      enveloped.addRecipientByCertificate(certData.certificate, { oaepHashAlgorithm: "SHA-256" });
+      await enveloped.encrypt({ name: "AES-GCM", length: 256 } as AesKeyGenParams, plaintext);
+
+      // Serialize and re-parse so the decrypt path runs against bytes, not a
+      // live object graph — this is how real consumers hit the decrypt code.
+      const raw = enveloped.toSchema().toBER(false);
+      const parsed = pkijs.EnvelopedData.fromBER(raw);
+
+      // Sanity check: the parsed structure still carries a GCMParameters SEQUENCE.
+      const innerParams = parsed.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams;
+      assert.strictEqual(innerParams.idBlock.tagNumber, SEQUENCE_TAG);
+
+      // Re-import the PKCS#8 private key as RSA-OAEP for recipient decryption.
+      const recipientKey = await webcrypto.subtle.importKey(
+        "pkcs8",
+        certData.pkcs8,
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        false,
+        ["decrypt"],
+      );
+      const decrypted = await parsed.decrypt(0, { recipientPrivateKey: recipientKey });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+  });
+  //#endregion
+});

--- a/test/gcmParams.spec.ts
+++ b/test/gcmParams.spec.ts
@@ -1,0 +1,642 @@
+import { describe, it, assert, expect } from "vitest";
+import * as asn1js from "asn1js";
+import * as pvtsutils from "pvtsutils";
+import { Crypto } from "@peculiar/webcrypto";
+import * as pkijs from "../src/index";
+import { createSelfSignedCertificate } from "./utils";
+
+// Several tests reach past pkijs to seal or malform a fixture WebCrypto-side.
+// The engine under test is the one test/vitest.setup.ts installs.
+const webcrypto = new Crypto();
+
+describe("GCMParams (RFC 5084 §3.2)", () => {
+  //#region Schema round-trip
+  describe("schema round-trip", () => {
+    it("encodes nonce + icvLen 16, parses back with identical values", () => {
+      const nonceBytes = new Uint8Array([
+        0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55
+      ]);
+      const original = new pkijs.GCMParams({ nonce: nonceBytes.buffer, icvLen: 16 });
+
+      const der = original.toSchema().toBER(false);
+      const parsed = new pkijs.GCMParams({ schema: asn1js.fromBER(der).result });
+
+      assert.strictEqual(
+        pvtsutils.Convert.ToHex(parsed.nonce),
+        pvtsutils.Convert.ToHex(nonceBytes.buffer)
+      );
+      assert.strictEqual(parsed.icvLen, 16);
+    });
+
+    it("omits icvLen from DER when value equals the RFC 5084 default (12)", () => {
+      const nonce = new Uint8Array(12).buffer;
+      const seq = new pkijs.GCMParams({ nonce, icvLen: 12 }).toSchema();
+      // SEQUENCE should contain only the OCTET STRING; the INTEGER for icvLen
+      // must be absent because 12 is the ASN.1 DEFAULT value.
+      assert.strictEqual(seq.valueBlock.value.length, 1);
+    });
+
+    it("round-trips with icvLen absent (parses as undefined)", () => {
+      const nonce = new Uint8Array(12).buffer;
+      const der = new pkijs.GCMParams({ nonce }).toSchema().toBER(false);
+      const parsed = new pkijs.GCMParams({ schema: asn1js.fromBER(der).result });
+
+      assert.strictEqual(pvtsutils.Convert.ToHex(parsed.nonce), pvtsutils.Convert.ToHex(nonce));
+      assert.strictEqual(parsed.icvLen, undefined);
+    });
+
+    it("defaults the nonce to an empty buffer when constructed with no parameters", () => {
+      const params = new pkijs.GCMParams();
+
+      assert.strictEqual(params.nonce.byteLength, 0);
+      assert.strictEqual(params.icvLen, undefined);
+    });
+
+    it("names every schema element when told to, and leaves them empty when not", () => {
+      const named = pkijs.GCMParams.schema({
+        names: { blockName: "gcm", nonce: "gcm-nonce", icvLen: "gcm-icvLen" }
+      }) as asn1js.Sequence;
+
+      assert.strictEqual(named.name, "gcm");
+      assert.strictEqual(named.valueBlock.value[0].name, "gcm-nonce");
+      assert.strictEqual(named.valueBlock.value[1].name, "gcm-icvLen");
+
+      const unnamed = pkijs.GCMParams.schema() as asn1js.Sequence;
+
+      assert.strictEqual(unnamed.name, "");
+      assert.strictEqual(unnamed.valueBlock.value[0].name, "");
+      assert.strictEqual(unnamed.valueBlock.value[1].name, "");
+    });
+
+    it("rejects an unknown member name in defaultValues", () => {
+      assert.throws(() => (pkijs.GCMParams as any).defaultValues("bogus"));
+    });
+
+    it("encodes to the DER an RFC 5084 reader expects", () => {
+      // Pinned so a change to the encoder has to be deliberate: an encoder and a
+      // decoder that drift together stay self-consistent and still fail interop.
+      const nonce = pvtsutils.Convert.FromHex("aabbccddeeff001122334455");
+
+      assert.strictEqual(
+        pvtsutils.Convert.ToHex(new pkijs.GCMParams({ nonce, icvLen: 16 }).toSchema().toBER(false)),
+        "3011040caabbccddeeff001122334455020110"
+      );
+      assert.strictEqual(
+        pvtsutils.Convert.ToHex(new pkijs.GCMParams({ nonce, icvLen: 12 }).toSchema().toBER(false)),
+        "300e040caabbccddeeff001122334455"
+      );
+    });
+
+    it("refuses an aes-ICVlen outside the RFC 5084 set, on parse and on emit", () => {
+      const nonce = pvtsutils.Convert.FromHex("aabbccddeeff001122334455");
+
+      for (const icvLen of [4, 8, 11, 17]) {
+        assert.throws(
+          () => new pkijs.GCMParams({ nonce, icvLen }).toSchema(),
+          /aes-ICVlen/,
+          `emit should refuse icvLen ${icvLen}`
+        );
+
+        // Same value arriving off the wire, where it would otherwise reach
+        // WebCrypto as a tag length.
+        const der = new asn1js.Sequence({
+          value: [
+            new asn1js.OctetString({ valueHex: nonce }),
+            new asn1js.Integer({ value: icvLen })
+          ]
+        }).toBER(false);
+
+        assert.throws(
+          () => new pkijs.GCMParams({ schema: asn1js.fromBER(der).result }),
+          /aes-ICVlen/,
+          `parse should refuse icvLen ${icvLen}`
+        );
+      }
+    });
+
+    it("accepts every aes-ICVlen the RFC permits", () => {
+      const nonce = pvtsutils.Convert.FromHex("aabbccddeeff001122334455");
+
+      for (const icvLen of [12, 13, 14, 15, 16]) {
+        const der = new pkijs.GCMParams({ nonce, icvLen }).toSchema().toBER(false);
+        const parsed = new pkijs.GCMParams({ schema: asn1js.fromBER(der).result });
+
+        // 12 is the DEFAULT, so it is absent from the DER and parses as undefined.
+        assert.strictEqual(parsed.icvLen, icvLen === 12 ? undefined : icvLen);
+      }
+    });
+
+    it("refuses an AES-GCM AlgorithmIdentifier that carries no parameters", () => {
+      // RFC 5084 Section 3.2 requires the parameters field to be present and to
+      // hold a GCMParameters, so an absent one cannot be read as an empty nonce.
+      assert.throws(() => pkijs.GCMParams.fromAlgorithmParams(undefined), /GCMParameters/);
+    });
+
+    it("refuses a zero-length aes-nonce", () => {
+      const der = new asn1js.Sequence({
+        value: [new asn1js.OctetString({ valueHex: new ArrayBuffer(0) })]
+      }).toBER(false);
+
+      assert.throws(() => new pkijs.GCMParams({ schema: asn1js.fromBER(der).result }), /aes-nonce/);
+    });
+
+    it("clears a previously set icvLen when re-parsing input that omits it", () => {
+      const nonce = pvtsutils.Convert.FromHex("aabbccddeeff001122334455");
+      const params = new pkijs.GCMParams({ nonce, icvLen: 16 });
+
+      const der = new pkijs.GCMParams({ nonce }).toSchema().toBER(false);
+      params.fromSchema(asn1js.fromBER(der).result);
+
+      // Re-emitting must not resurrect the icvLen the new input never carried.
+      assert.strictEqual(params.icvLen, undefined);
+      assert.strictEqual(
+        pvtsutils.Convert.ToHex(params.toSchema().toBER(false)),
+        "300e040caabbccddeeff001122334455"
+      );
+    });
+
+    it("toJSON carries the nonce and omits icvLen at the RFC 5084 default", () => {
+      const nonce = new Uint8Array([
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c
+      ]).buffer;
+
+      const tagged = new pkijs.GCMParams({ nonce, icvLen: 16 }).toJSON();
+      assert.strictEqual(tagged.nonce.toLowerCase(), pvtsutils.Convert.ToHex(nonce));
+      assert.strictEqual(tagged.icvLen, 16);
+
+      const defaulted = new pkijs.GCMParams({ nonce, icvLen: 12 }).toJSON();
+      assert.strictEqual(defaulted.icvLen, undefined);
+    });
+  });
+  //#endregion
+
+  //#region PBES2 with AES-GCM
+  describe("PBES2 encrypt/decrypt with AES-GCM (issue #486)", () => {
+    const password = new TextEncoder().encode("test-password").buffer;
+    const contentType = "1.2.840.113549.1.7.1"; // id-data
+
+    async function encryptSample(plaintext: ArrayBuffer) {
+      const crypto = pkijs.getCrypto(true);
+      return crypto.encryptEncryptedContentInfo({
+        password,
+        // `ContentEncryptionAesGcmParams` requires `iv`, but the encrypt method
+        // generates its own nonce and ignores the one on the input. Cast to
+        // `any` to satisfy the type without supplying a throwaway IV.
+        contentEncryptionAlgorithm: { name: "AES-GCM", length: 256 } as any,
+        hmacHashAlgorithm: "SHA-256",
+        iterationCount: 1000,
+        contentType,
+        contentToEncrypt: plaintext
+      });
+    }
+
+    it("emits inner AES-GCM AlgorithmIdentifier.algorithmParams as a SEQUENCE", async () => {
+      const plaintext = new TextEncoder().encode("hello gcm").buffer;
+      const eci = await encryptSample(plaintext);
+
+      // The outer AlgorithmIdentifier is pkcs5PBES2; unwrap to reach the inner cipher AI.
+      const pbes2 = new pkijs.PBES2Params({
+        schema: eci.contentEncryptionAlgorithm.algorithmParams
+      });
+      const innerParams = pbes2.encryptionScheme.algorithmParams;
+
+      // Before the fix these parameters were a bare OCTET STRING carrying the IV.
+      assert.ok(
+        innerParams instanceof asn1js.Sequence,
+        "AES-GCM AlgorithmIdentifier.parameters must be a GCMParameters SEQUENCE per RFC 5084 §3.2"
+      );
+
+      const gcmParams = new pkijs.GCMParams({ schema: innerParams });
+      assert.strictEqual(
+        gcmParams.nonce.byteLength,
+        12,
+        "AES-GCM nonce should be 12 bytes (RFC 5084)"
+      );
+      assert.strictEqual(
+        gcmParams.icvLen,
+        16,
+        "ICV length must reflect WebCrypto's 128-bit default tag"
+      );
+    });
+
+    it("normalizes a lower-case algorithm name and still emits a SEQUENCE", async () => {
+      // `getOIDByAlgorithm` upper-cases before matching, so "aes-gcm" resolves to
+      // the AES-GCM OID. The parameter encoding has to follow the same
+      // normalization, or a case variant silently falls back to a bare OCTET STRING.
+      const plaintext = new TextEncoder().encode("lower-case gcm").buffer;
+      const crypto = pkijs.getCrypto(true);
+      const eci = await crypto.encryptEncryptedContentInfo({
+        password,
+        contentEncryptionAlgorithm: { name: "aes-gcm", length: 256 } as any,
+        hmacHashAlgorithm: "SHA-256",
+        iterationCount: 1000,
+        contentType,
+        contentToEncrypt: plaintext
+      });
+
+      const pbes2 = new pkijs.PBES2Params({
+        schema: eci.contentEncryptionAlgorithm.algorithmParams
+      });
+      assert.ok(pbes2.encryptionScheme.algorithmParams instanceof asn1js.Sequence);
+      assert.strictEqual(
+        new pkijs.GCMParams({ schema: pbes2.encryptionScheme.algorithmParams }).nonce.byteLength,
+        12
+      );
+    });
+
+    it("decrypt recovers the original plaintext (new-format round-trip)", async () => {
+      const plaintext = new TextEncoder().encode("hello gcm round-trip").buffer;
+      const eci = await encryptSample(plaintext);
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("legacy fallback: decrypts a blob whose params are a bare OCTET STRING", async () => {
+      const plaintext = new TextEncoder().encode("legacy gcm output").buffer;
+      const eci = await encryptSample(plaintext);
+
+      // Simulate pre-fix pkijs output by rewriting the inner algorithmParams from
+      // GCMParameters SEQUENCE back to a bare OCTET STRING carrying the same nonce.
+      // The ciphertext stays valid because it was encrypted with that exact nonce.
+      const pbes2 = new pkijs.PBES2Params({
+        schema: eci.contentEncryptionAlgorithm.algorithmParams
+      });
+      const gcm = new pkijs.GCMParams({ schema: pbes2.encryptionScheme.algorithmParams });
+      pbes2.encryptionScheme.algorithmParams = new asn1js.OctetString({ valueHex: gcm.nonce });
+      eci.contentEncryptionAlgorithm.algorithmParams = pbes2.toSchema();
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("legacy fallback: decrypts an authentic pre-fix blob with 16-byte nonce", async () => {
+      // Pre-fix pkijs always generated a 16-byte IV (new ArrayBuffer(16) in
+      // encryptEncryptedContentInfo) regardless of cipher. This test reconstructs
+      // an exact pre-fix shape: 16-byte nonce inside a bare OCTET STRING, with
+      // matching ciphertext produced by WebCrypto using that same 16-byte IV.
+      const plaintext = new TextEncoder().encode("authentic pre-fix gcm blob").buffer;
+
+      const salt = new Uint8Array(64);
+      webcrypto.getRandomValues(salt);
+      const nonce16 = new Uint8Array(16);
+      webcrypto.getRandomValues(nonce16);
+      const iterationCount = 1000;
+
+      const pbkdfKey = await webcrypto.subtle.importKey(
+        "raw",
+        new Uint8Array(password),
+        "PBKDF2",
+        false,
+        ["deriveKey"]
+      );
+      const aesKey = await webcrypto.subtle.deriveKey(
+        { name: "PBKDF2", hash: "SHA-256", salt, iterations: iterationCount },
+        pbkdfKey,
+        { name: "AES-GCM", length: 256 },
+        false,
+        ["encrypt"]
+      );
+      const ciphertext = await webcrypto.subtle.encrypt(
+        { name: "AES-GCM", iv: nonce16 },
+        aesKey,
+        new Uint8Array(plaintext)
+      );
+
+      // Build the PBES2Params manually with the legacy shape: bare OCTET STRING
+      // in encryptionScheme.algorithmParams instead of a GCMParameters SEQUENCE.
+      const pbes2 = new pkijs.PBES2Params({
+        keyDerivationFunc: new pkijs.AlgorithmIdentifier({
+          algorithmId: "1.2.840.113549.1.5.12", // id-PBKDF2
+          algorithmParams: new pkijs.PBKDF2Params({
+            salt: new asn1js.OctetString({ valueHex: salt.buffer }),
+            iterationCount,
+            prf: new pkijs.AlgorithmIdentifier({
+              algorithmId: "1.2.840.113549.2.9", // hmacWithSHA256
+              algorithmParams: new asn1js.Null()
+            })
+          }).toSchema()
+        }),
+        encryptionScheme: new pkijs.AlgorithmIdentifier({
+          algorithmId: "2.16.840.1.101.3.4.1.46", // aes256-GCM
+          algorithmParams: new asn1js.OctetString({ valueHex: nonce16.buffer })
+        })
+      });
+
+      const eci = new pkijs.EncryptedContentInfo({
+        contentType,
+        contentEncryptionAlgorithm: new pkijs.AlgorithmIdentifier({
+          algorithmId: "1.2.840.113549.1.5.13", // pkcs5PBES2
+          algorithmParams: pbes2.toSchema()
+        }),
+        encryptedContent: new asn1js.OctetString({ valueHex: ciphertext })
+      });
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("surfaces a malformed GCMParameters instead of reading it as a raw IV", async () => {
+      // A SEQUENCE that is not GCMParameters must not be mistaken for the legacy
+      // bare-OCTET-STRING shape: a constructed block carries no valueHex, so
+      // treating it as one yields a zero-length IV and an unrelated error.
+      const plaintext = new TextEncoder().encode("malformed params").buffer;
+      const eci = await encryptSample(plaintext);
+
+      const pbes2 = new pkijs.PBES2Params({
+        schema: eci.contentEncryptionAlgorithm.algorithmParams
+      });
+      pbes2.encryptionScheme.algorithmParams = new asn1js.Sequence({
+        value: [new asn1js.Integer({ value: 12 })]
+      });
+      eci.contentEncryptionAlgorithm.algorithmParams = pbes2.toSchema();
+
+      const crypto = pkijs.getCrypto(true);
+      await expect(
+        crypto.decryptEncryptedContentInfo({ password, encryptedContentInfo: eci })
+      ).rejects.toThrow(/schema/i);
+    });
+
+    it("rejects a tampered ciphertext", async () => {
+      const plaintext = new TextEncoder().encode("integrity still enforced").buffer;
+      const eci = await encryptSample(plaintext);
+
+      const sealed = new Uint8Array(eci.getEncryptedContent().slice(0));
+      sealed[0] ^= 0xff;
+      eci.encryptedContent = new asn1js.OctetString({ valueHex: sealed.buffer });
+
+      const crypto = pkijs.getCrypto(true);
+      await expect(
+        crypto.decryptEncryptedContentInfo({ password, encryptedContentInfo: eci })
+      ).rejects.toThrow(Error);
+    });
+
+    it("rejects a substituted nonce", async () => {
+      const plaintext = new TextEncoder().encode("nonce is authenticated too").buffer;
+      const eci = await encryptSample(plaintext);
+
+      const pbes2 = new pkijs.PBES2Params({
+        schema: eci.contentEncryptionAlgorithm.algorithmParams
+      });
+      const other = new Uint8Array(12);
+      webcrypto.getRandomValues(other);
+      pbes2.encryptionScheme.algorithmParams = new pkijs.GCMParams({
+        nonce: other.buffer,
+        icvLen: 16
+      }).toSchema();
+      eci.contentEncryptionAlgorithm.algorithmParams = pbes2.toSchema();
+
+      const crypto = pkijs.getCrypto(true);
+      await expect(
+        crypto.decryptEncryptedContentInfo({ password, encryptedContentInfo: eci })
+      ).rejects.toThrow(Error);
+    });
+
+    it("honors the RFC 5084 icvLen default of 12 when the INTEGER is absent", async () => {
+      // DER omits a DEFAULT, so GCMParameters carrying only a nonce means a
+      // 12-octet ICV. WebCrypto's own default is 16, and reading it that way
+      // would put the tag boundary four octets late.
+      const plaintext = new TextEncoder().encode("default icv length").buffer;
+
+      const salt = new Uint8Array(64);
+      webcrypto.getRandomValues(salt);
+      const nonce = new Uint8Array(12);
+      webcrypto.getRandomValues(nonce);
+      const iterationCount = 1000;
+
+      const pbkdfKey = await webcrypto.subtle.importKey(
+        "raw",
+        new Uint8Array(password),
+        "PBKDF2",
+        false,
+        ["deriveKey"]
+      );
+      const aesKey = await webcrypto.subtle.deriveKey(
+        { name: "PBKDF2", hash: "SHA-256", salt, iterations: iterationCount },
+        pbkdfKey,
+        { name: "AES-GCM", length: 256 },
+        false,
+        ["encrypt"]
+      );
+      const ciphertext = await webcrypto.subtle.encrypt(
+        { name: "AES-GCM", iv: nonce, tagLength: 96 },
+        aesKey,
+        new Uint8Array(plaintext)
+      );
+
+      const pbes2 = new pkijs.PBES2Params({
+        keyDerivationFunc: new pkijs.AlgorithmIdentifier({
+          algorithmId: "1.2.840.113549.1.5.12", // id-PBKDF2
+          algorithmParams: new pkijs.PBKDF2Params({
+            salt: new asn1js.OctetString({ valueHex: salt.buffer }),
+            iterationCount,
+            prf: new pkijs.AlgorithmIdentifier({
+              algorithmId: "1.2.840.113549.2.9", // hmacWithSHA256
+              algorithmParams: new asn1js.Null()
+            })
+          }).toSchema()
+        }),
+        encryptionScheme: new pkijs.AlgorithmIdentifier({
+          algorithmId: "2.16.840.1.101.3.4.1.46", // aes256-GCM
+          algorithmParams: new pkijs.GCMParams({ nonce: nonce.buffer }).toSchema()
+        })
+      });
+
+      const eci = new pkijs.EncryptedContentInfo({
+        contentType,
+        contentEncryptionAlgorithm: new pkijs.AlgorithmIdentifier({
+          algorithmId: "1.2.840.113549.1.5.13", // pkcs5PBES2
+          algorithmParams: pbes2.toSchema()
+        }),
+        encryptedContent: new asn1js.OctetString({ valueHex: ciphertext })
+      });
+
+      const crypto = pkijs.getCrypto(true);
+      const decrypted = await crypto.decryptEncryptedContentInfo({
+        password,
+        encryptedContentInfo: eci
+      });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("round-trips a private key through the PKCS#12 privacy layer", async () => {
+      // PKCS8ShroudedKeyBag protects its key through EncryptedData, so this is the
+      // AlgorithmIdentifier a PFX carries.
+      const keyPair = await webcrypto.subtle.generateKey(
+        {
+          name: "RSASSA-PKCS1-v1_5",
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+          hash: "SHA-256"
+        },
+        true,
+        ["sign", "verify"]
+      );
+      const pkcs8 = await webcrypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+
+      const encrypted = new pkijs.EncryptedData();
+      await encrypted.encrypt({
+        contentEncryptionAlgorithm: { name: "AES-GCM", length: 256 } as any,
+        hmacHashAlgorithm: "SHA-256",
+        iterationCount: 1000,
+        password,
+        contentToEncrypt: pkcs8
+      });
+
+      const pbes2 = new pkijs.PBES2Params({
+        schema: encrypted.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams
+      });
+      assert.ok(pbes2.encryptionScheme.algorithmParams instanceof asn1js.Sequence);
+
+      const reparsed = pkijs.EncryptedData.fromBER(encrypted.toSchema().toBER(false));
+      const recovered = await reparsed.decrypt({ password });
+
+      assert.strictEqual(pvtsutils.Convert.ToHex(recovered), pvtsutils.Convert.ToHex(pkcs8));
+      // And the recovered octets are still a well-formed PKCS#8 key.
+      assert.ok(pkijs.PrivateKeyInfo.fromBER(recovered).privateKeyAlgorithm.algorithmId.length > 0);
+    });
+  });
+  //#endregion
+
+  //#region CMS EnvelopedData with AES-GCM
+  describe("EnvelopedData AES-GCM emission (issue #287)", () => {
+    it("emits the inner AES-GCM AlgorithmIdentifier.algorithmParams as a SEQUENCE", async () => {
+      const plaintext = new TextEncoder().encode("hello enveloped").buffer;
+
+      // EnvelopedData.encrypt builds encryptedContentInfo regardless of whether
+      // any recipient infos are attached, so no recipient setup is needed to
+      // exercise the AlgorithmIdentifier emission path.
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      await enveloped.encrypt({ name: "AES-GCM", length: 256 } as AesKeyGenParams, plaintext);
+
+      const innerParams = enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams;
+      assert.ok(
+        innerParams instanceof asn1js.Sequence,
+        "CMS AES-GCM AlgorithmIdentifier.parameters must be a GCMParameters SEQUENCE per RFC 5084 §3.2"
+      );
+
+      const gcmParams = new pkijs.GCMParams({ schema: innerParams });
+      assert.strictEqual(gcmParams.nonce.byteLength, 12);
+      assert.strictEqual(gcmParams.icvLen, 16);
+    });
+
+    it("normalizes a lower-case algorithm name and still emits a SEQUENCE", async () => {
+      const plaintext = new TextEncoder().encode("lower-case enveloped").buffer;
+
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      await enveloped.encrypt({ name: "aes-gcm", length: 256 } as AesKeyGenParams, plaintext);
+
+      const innerParams = enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams;
+      assert.ok(innerParams instanceof asn1js.Sequence);
+      assert.strictEqual(new pkijs.GCMParams({ schema: innerParams }).nonce.byteLength, 12);
+    });
+
+    it("full round-trip via RSA-OAEP cert recipient: encrypt → BER → parse → decrypt", async () => {
+      // End-to-end proof that EnvelopedData's decrypt path correctly handles
+      // the new GCMParameters SEQUENCE — mirrors the CryptoEngine new-format
+      // round-trip but exercises the separate EnvelopedData decrypt code path.
+      const plaintext = new TextEncoder().encode("cms enveloped round-trip payload").buffer;
+      const certData = await createSelfSignedCertificate("SHA-256", "RSASSA-PKCS1-v1_5");
+
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      enveloped.addRecipientByCertificate(certData.certificate, { oaepHashAlgorithm: "SHA-256" });
+      await enveloped.encrypt({ name: "AES-GCM", length: 256 } as AesKeyGenParams, plaintext);
+
+      // Serialize and re-parse so the decrypt path runs against bytes, not a
+      // live object graph — this is how real consumers hit the decrypt code.
+      const raw = enveloped.toSchema().toBER(false);
+      const parsed = pkijs.EnvelopedData.fromBER(raw);
+
+      // Sanity check: the parsed structure still carries a GCMParameters SEQUENCE.
+      const innerParams = parsed.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams;
+      assert.ok(innerParams instanceof asn1js.Sequence);
+
+      // Re-import the PKCS#8 private key as RSA-OAEP for recipient decryption.
+      const recipientKey = await webcrypto.subtle.importKey(
+        "pkcs8",
+        certData.pkcs8,
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        false,
+        ["decrypt"]
+      );
+      const decrypted = await parsed.decrypt(0, { recipientPrivateKey: recipientKey });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("legacy fallback: decrypts a blob whose params are a bare OCTET STRING", async () => {
+      const plaintext = new TextEncoder().encode("legacy enveloped output").buffer;
+      const certData = await createSelfSignedCertificate("SHA-256", "RSASSA-PKCS1-v1_5");
+
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      enveloped.addRecipientByCertificate(certData.certificate, { oaepHashAlgorithm: "SHA-256" });
+      await enveloped.encrypt({ name: "AES-GCM", length: 256 } as AesKeyGenParams, plaintext);
+
+      // Rewrite the parameters to the pre-fix shape: a bare OCTET STRING holding
+      // the same nonce. The ciphertext stays valid because the fallback leaves
+      // WebCrypto on the 128-bit tag that produced it.
+      const gcm = new pkijs.GCMParams({
+        schema: enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams
+      });
+      enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams =
+        new asn1js.OctetString({ valueHex: gcm.nonce });
+
+      const recipientKey = await webcrypto.subtle.importKey(
+        "pkcs8",
+        certData.pkcs8,
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        false,
+        ["decrypt"]
+      );
+      const decrypted = await enveloped.decrypt(0, { recipientPrivateKey: recipientKey });
+      assert.strictEqual(pvtsutils.Convert.ToHex(decrypted), pvtsutils.Convert.ToHex(plaintext));
+    });
+
+    it("honors the RFC 5084 icvLen default of 12 when the INTEGER is absent", async () => {
+      // The content was sealed under WebCrypto's 16-octet ICV. Dropping the
+      // explicit icvLen leaves the DEFAULT of 12, which moves the tag boundary,
+      // so the open must fail rather than hand back four octets of tag as data.
+      const plaintext = new TextEncoder().encode("icv default enveloped").buffer;
+      const certData = await createSelfSignedCertificate("SHA-256", "RSASSA-PKCS1-v1_5");
+
+      const enveloped = new pkijs.EnvelopedData({ version: 0 });
+      enveloped.addRecipientByCertificate(certData.certificate, { oaepHashAlgorithm: "SHA-256" });
+      await enveloped.encrypt({ name: "AES-GCM", length: 256 } as AesKeyGenParams, plaintext);
+
+      const gcm = new pkijs.GCMParams({
+        schema: enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams
+      });
+      const recipientKey = await webcrypto.subtle.importKey(
+        "pkcs8",
+        certData.pkcs8,
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        false,
+        ["decrypt"]
+      );
+
+      // Open it once untouched, so the rejection below cannot be blamed on the
+      // recipient, the nonce or the ciphertext.
+      const control = await enveloped.decrypt(0, { recipientPrivateKey: recipientKey });
+      assert.strictEqual(pvtsutils.Convert.ToHex(control), pvtsutils.Convert.ToHex(plaintext));
+
+      enveloped.encryptedContentInfo.contentEncryptionAlgorithm.algorithmParams =
+        new pkijs.GCMParams({ nonce: gcm.nonce }).toSchema();
+
+      await expect(enveloped.decrypt(0, { recipientPrivateKey: recipientKey })).rejects.toThrow(
+        Error
+      );
+    });
+  });
+  //#endregion
+});


### PR DESCRIPTION
When constructing a PKCS#12 PFX or CMS EnvelopedData with `contentEncryptionAlgorithm: { name: "AES-GCM", ... }`, pkijs emits the AlgorithmIdentifier with `parameters` as a bare `OCTET STRING` carrying the IV. RFC 5084 §3.2 requires the parameter value to be a `GCMParameters` SEQUENCE instead:

```asn1
GCMParameters ::= SEQUENCE {
  aes-nonce        OCTET STRING,
  aes-ICVlen       AES-GCM-ICVlen DEFAULT 12 }

AES-GCM-ICVlen ::= INTEGER (12 | 13 | 14 | 15 | 16)
```

A bare `OCTET STRING` is not a `GCMParameters`, so what pkijs writes today is not
what a reader implementing RFC 5084 expects to parse. The same-shape bug exists
independently on the CMS EnvelopedData path, tracked separately as #287.

## Scope

Two emission sites, same root cause, both fixed:

- `CryptoEngine.encryptEncryptedContentInfo` (used by PKCS#12 `PKCS8ShroudedKeyBag` and `AuthenticatedSafe`) — refs #486
- `EnvelopedData.encrypt` (CMS path) — refs #287

This corrects the encoding. It does not, on its own, make either payload
interoperable with OpenSSL, and neither issue is closed by it:

- PBES2 (#486): OpenSSL declines AEAD ciphers in PBES2 whatever the parameters
  say — `openssl pkcs8 -v2 aes-256-gcm` answers `AEAD ciphers not supported`, and
  importing a PFX built this way still ends in
  `PKCS5_v2_PBE_keyivgen_ex: cipher parameter error`.
- CMS (#287): RFC 5084 scopes AES-GCM to the RFC 5083 `AuthEnvelopedData`
  content type, which pkijs does not implement. `openssl cms -encrypt
  -aes-128-gcm` emits `AuthEnvelopedData`, not `EnvelopedData`.

Both remainders are the same shape: AES-GCM in a container with no `mac` field
to carry the ICV. That is a larger change than this one and is left to the
issues.

## Changes

- New `src/GCMParams.ts` — RFC 5084 §3.2 `GCMParameters` schema class, modeled on `PBKDF2Params`
- New `test/gcmParams.spec.ts` — 28 tests
- `src/CryptoEngine/CryptoEngine.ts` — detect AES-GCM, generate a 12-octet nonce (the size RFC 5084 recommends), emit `GCMParams.toSchema()` on encrypt, and read the parameters back through `GCMParams.fromAlgorithmParams` on decrypt
- `src/EnvelopedData.ts` — same pattern for the CMS path
- `src/index.ts` — alphabetical re-export of `GCMParams`

`GCMParams.fromAlgorithmParams` is where both paths read an AES-GCM
`AlgorithmIdentifier`: it returns the nonce, and the tag length where the
parameters state one. Keeping it in one place means the ICV default and the
compatibility shape below cannot drift apart between the PBES2 and CMS callers.

## Value constraints

`aes-ICVlen` reaches WebCrypto as a tag length, and the `AlgorithmIdentifier`
carrying it is not authenticated, so the value is checked rather than trusted.
`GCMParams` rejects an `aes-ICVlen` outside RFC 5084's
`INTEGER (12 | 13 | 14 | 15 | 16)` on both parse and emit, rejects a zero-length
`aes-nonce`, and rejects an AES-GCM `AlgorithmIdentifier` whose parameters field
is absent, which §3.2 requires to be present. Without the range check a blob
declaring `aes-ICVlen 4` authenticates under a 32-bit tag.

The `GCMParameters` ASN.1 type name is capitalized per RFC 5084, but the JS class follows the `*Params` convention established by `PBKDF2Params`, `PBES2Params`, `RSAESOAEPParams`, `RSASSAPSSParams` in this package. Comments and ASN.1 blocks still reference the RFC type name `GCMParameters`.

## Backward compatibility

Where the parameters are a bare `OCTET STRING` rather than a GCMParameters
SEQUENCE, it is read as a raw IV and WebCrypto keeps its own 128-bit tag length,
so pkijs still opens the AES-GCM blobs it produced before this change. That shape
is matched on the `OCTET STRING` itself, so a GCMParameters that fails to parse
raises its schema error instead of being taken for a legacy blob.

## Tests

Schema:
- encodes nonce + icvLen 16, parses back with identical values
- omits icvLen from DER when value equals the RFC 5084 default (12)
- round-trips with icvLen absent (parses as undefined)
- defaults the nonce to an empty buffer when constructed with no parameters
- names every schema element when told to, and leaves them empty when not
- rejects an unknown member name in defaultValues
- encodes to the DER an RFC 5084 reader expects
- refuses an aes-ICVlen outside the RFC 5084 set, on parse and on emit
- accepts every aes-ICVlen the RFC permits
- refuses an AES-GCM AlgorithmIdentifier that carries no parameters
- refuses a zero-length aes-nonce
- clears a previously set icvLen when re-parsing input that omits it
- toJSON carries the nonce and omits icvLen at the RFC 5084 default

PBES2 path (#486):
- emits inner AES-GCM AlgorithmIdentifier.algorithmParams as a SEQUENCE
- normalizes a lower-case algorithm name and still emits a SEQUENCE
- decrypt recovers the original plaintext (new-format round-trip)
- legacy fallback: decrypts a blob whose params are a bare OCTET STRING
- legacy fallback: decrypts an authentic pre-fix blob with 16-byte nonce
- surfaces a malformed GCMParameters instead of reading it as a raw IV
- rejects a tampered ciphertext
- rejects a substituted nonce
- honors the RFC 5084 icvLen default of 12 when the INTEGER is absent
- round-trips a private key through the PKCS#12 privacy layer

CMS EnvelopedData path (#287):
- emits the inner AES-GCM AlgorithmIdentifier.algorithmParams as a SEQUENCE
- normalizes a lower-case algorithm name and still emits a SEQUENCE
- full round-trip via RSA-OAEP cert recipient: encrypt → BER → parse → decrypt
- legacy fallback: decrypts a blob whose params are a bare OCTET STRING
- honors the RFC 5084 icvLen default of 12 when the INTEGER is absent

Both `normalizes a lower-case algorithm name` cases cover the same gap on the two
paths: `getOIDByAlgorithm` matches on `algorithm.name.toUpperCase()`, so `aes-gcm`
resolves to the AES-GCM OID. The parameter encoding follows that normalization,
otherwise a case variant emits the AES-GCM OID beside a bare OCTET STRING.

`encodes to the DER an RFC 5084 reader expects` pins the two shapes the encoder
emits as literal hex, so a change to the encoder cannot quietly agree with a
matching change to the decoder and still fail a third-party reader.

`src/GCMParams.ts` is at 100% line, branch and function coverage, and the changed
regions of the other two files carry no uncovered line or branch. Full suite:
1764 passing, 57 skipped. Lint clean. `tsc --noEmit` clean.

## The adjacent TODO

`encryptEncryptedContentInfo` carries a note directly above the line this changes:

```ts
// TODO Should we reuse iv from parameters.contentEncryptionAlgorithm or use it's length for ivBuffer?
```

It is left in place. Both readings resolve to "no", and the change that would
settle the question properly is a breaking one.

**Reusing the caller's `iv`.** `ContentEncryptionAesGcmParams` is
`AesGcmParams & AesDerivedKeyParams`, and `AesGcmParams` declares `iv` as
required, so every caller already supplies a value that the method discards.
Whatever satisfies the type is in there today: a zero buffer, a constant, a value
shared across calls. Honoring the field would turn those into fixed GCM nonces at
upgrade, and a repeated key-nonce pair under GCM exposes the hash subkey and
admits forgery, not only a plaintext XOR. Nothing collides at present because the
key differs per call, from a fresh 64-byte PBKDF2 salt here and a generated
content-encryption key in `EnvelopedData.encrypt`. That makes nonce hygiene a
property of salt and key generation rather than of the nonce, and it holds only
until a caller can supply either one.

**Taking the length from that field.** A 96-bit nonce is the size RFC 5084
recommends for AES-GCM. This sizes the buffer from the algorithm, 12 bytes for
GCM and 16 otherwise, in place of the flat 16 that preceded it. Reading the
length from the caller would put the shorter cases back.

What remains is that `iv` is required and ignored. Making it optional changes the
published types, so it is not attempted here.

Refs #486
Refs #287


