### PR TITLE
Lessen restrictions on @noble/hashes and permit legacy update to v1.8.+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@noble/hashes": "1.4.0",
         "asn1js": "^3.0.6",
         "bytestreamjs": "^2.0.1",
         "pvtsutils": "^1.3.6",
@@ -17,6 +16,7 @@
         "tslib": "^2.8.1"
       },
       "devDependencies": {
+        "@noble/hashes": "^1.8.0",
         "@peculiar/webcrypto": "^1.5.0",
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-commonjs": "^28.0.7",
@@ -759,12 +759,13 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@noble/hashes": "1.4.0",
+    "@noble/hashes": "^1.8.0",
     "asn1js": "^3.0.6",
     "bytestreamjs": "^2.0.1",
     "pvtsutils": "^1.3.6",


### PR DESCRIPTION
Lessen restrictions on @noble/hashes in package.json and permit legacy update to v1.8.+.  An attempt to resolve https://github.com/PeculiarVentures/PKI.js/issues/459