### PR TITLE
ci: run library build in GitHub Actions

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run format check
         run: npm run format:check
 
+      - name: Run build
+        run: npm run build
+
       - name: Run test with coverage
         run: npm run coverage
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,6 +20,8 @@ export default [
       typescript({
         check: true,
         clean: true,
+        // Default "*.ts+(|x)" no longer matches .ts with current @rollup/pluginutils
+        include: ["*.ts", "**/*.ts"],
         tsconfigOverride: {
           compilerOptions: {
             module: "ES2020",


### PR DESCRIPTION
## Summary
- Adds an `npm run build` step to the library CI workflow (after format check, before coverage).
- Fixes Rollup TypeScript include patterns so `.ts` modules resolve again with current `@rollup/pluginutils`.

## CI failed (before fix)
Confirmed on this PR that CI reproduces the local build failure:

- Job: [build (22.x)](https://github.com/PeculiarVentures/PKI.js/actions/runs/30351067257/job/90248431883?pr=519)
- Step: **Run build** exited with code 1 (`Could not resolve "./PkiObject"` / similar Rollup resolve failure)

This follow-up commit adds the `rollup.config.mjs` `include` override so CI build should pass.