### PR TITLE
ci: bump actions/checkout and setup-node to v7

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -61,11 +61,11 @@ jobs:
     needs: build
     if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: "npm"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: "npm"


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v5 to v7 in library and website workflows
- Bump `actions/setup-node` from v6 to v7 in library and website workflows